### PR TITLE
Add popup reminders to Whole Foods order calendar events

### DIFF
--- a/src/api_routes.cpp
+++ b/src/api_routes.cpp
@@ -457,7 +457,7 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
             std::string ingredients = body["ingredients"].s();
 
             std::string eventId =
-                calendarService->createEvent("Whole Foods Order", ingredients, start, end);
+                calendarService->createEvent("Whole Foods Order", ingredients, start, end, true);
             if (!eventId.empty()) {
                 CROW_LOG_INFO << "Created Whole Foods order calendar event";
                 crow::json::wvalue result;

--- a/src/calendar_service.cpp
+++ b/src/calendar_service.cpp
@@ -11,13 +11,22 @@
 CalendarService::CalendarService(std::shared_ptr<GoogleOAuth> oauth) : d_oauth(std::move(oauth)) {}
 
 std::string CalendarService::createEvent(const std::string &summary, const std::string &description,
-                                         const std::string &startTime, const std::string &endTime) {
+                                         const std::string &startTime, const std::string &endTime,
+                                         bool withReminders) {
     crow::json::wvalue body;
     body["summary"] = summary;
     body["description"] = description;
     body["start"]["dateTime"] = startTime;
     body["end"]["dateTime"] = endTime;
     body["extendedProperties"]["private"]["mealPrepApp"] = "true";
+
+    if (withReminders) {
+        body["reminders"]["useDefault"] = false;
+        body["reminders"]["overrides"][0]["method"] = "popup";
+        body["reminders"]["overrides"][0]["minutes"] = 2880;  // 2 days prior
+        body["reminders"]["overrides"][1]["method"] = "popup";
+        body["reminders"]["overrides"][1]["minutes"] = 1440;  // 1 day prior
+    }
 
     std::string response = makeAuthorizedRequest(
         "https://www.googleapis.com/calendar/v3/calendars/primary/events", "POST", body.dump());

--- a/src/calendar_service.h
+++ b/src/calendar_service.h
@@ -22,7 +22,8 @@ class CalendarService {
      * @return The created event ID, or empty string on failure.
      */
     std::string createEvent(const std::string &summary, const std::string &description,
-                            const std::string &startTime, const std::string &endTime);
+                            const std::string &startTime, const std::string &endTime,
+                            bool withReminders = false);
 
     bool deleteEvent(const std::string &eventId);
 


### PR DESCRIPTION
Two popup notifications are added only when creating a Whole Foods order
event: one 2 days prior (2880 min) and one 1 day prior (1440 min).

Added an optional `withReminders` parameter (default false) to
`createEvent` so meal sync events are unaffected.

https://claude.ai/code/session_01BzCX6PpMWGTiWxwzGiwo82