### PR TITLE
Upgrade Ubuntu base to 24.04 and remove LLVM PPA

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-test:
     name: build (-Werror) + ctest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/clang-lint.yml
+++ b/.github/workflows/clang-lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lintenator:
     name: lintenator (clang-tidy + clang-format)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -22,18 +22,13 @@ jobs:
             build-essential \
             cmake \
             git \
-            curl \
-            gnupg \
             libssl-dev \
             libboost-dev \
             libcurl4-openssl-dev \
-            libsqlite3-dev
-          curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/llvm.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" \
-            | sudo tee /etc/apt/sources.list.d/llvm-18.list
-          sudo apt-get update
-          sudo apt-get install -y clang-18 clang-tidy-18 clang-format-18
+            libsqlite3-dev \
+            clang-18 \
+            clang-tidy-18 \
+            clang-format-18
           sudo ln -sf /usr/bin/clang-18 /usr/local/bin/clang
           sudo ln -sf /usr/bin/clang++-18 /usr/local/bin/clang++
           sudo ln -sf /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy

--- a/.github/workflows/clang-lint.yml
+++ b/.github/workflows/clang-lint.yml
@@ -26,13 +26,9 @@ jobs:
             libboost-dev \
             libcurl4-openssl-dev \
             libsqlite3-dev \
-            clang-18 \
-            clang-tidy-18 \
-            clang-format-18
-          sudo ln -sf /usr/bin/clang-18 /usr/local/bin/clang
-          sudo ln -sf /usr/bin/clang++-18 /usr/local/bin/clang++
-          sudo ln -sf /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy
-          sudo ln -sf /usr/bin/clang-format-18 /usr/local/bin/clang-format
+            clang \
+            clang-tidy \
+            clang-format
 
       - name: Cache CMake FetchContent
         uses: actions/cache@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   coverage:
     name: code coverage (lcov)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   asan-ubsan:
     name: AddressSanitizer + UBSan
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -56,7 +56,7 @@ jobs:
 
   tsan:
     name: ThreadSanitizer
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # --- Stage 1: Build Environment ---
-FROM ubuntu:22.04 AS build-env
+FROM ubuntu:24.04 AS build-env
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -9,18 +9,12 @@ RUN apt-get update && apt-get install -y \
     git \
     gh \
     curl \
-    gnupg \
-    lsb-release \
     sudo \
     libssl-dev \
     libboost-dev \
     libcurl4-openssl-dev \
     libasio-dev \
     libsqlite3-dev \
-    && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" \
-       > /etc/apt/sources.list.d/llvm-18.list \
-    && apt-get update && apt-get install -y \
     clang-18 \
     clang-tidy-18 \
     clang-format-18 \
@@ -42,7 +36,7 @@ USER devuser
 RUN make internal-build
 
 # --- Stage 2: Production Environment ---
-FROM ubuntu:22.04 AS prod-env
+FROM ubuntu:24.04 AS prod-env
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,9 @@ RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libasio-dev \
     libsqlite3-dev \
-    clang-18 \
-    clang-tidy-18 \
-    clang-format-18 \
-    && ln -sf /usr/bin/clang-18 /usr/local/bin/clang \
-    && ln -sf /usr/bin/clang++-18 /usr/local/bin/clang++ \
-    && ln -sf /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy \
-    && ln -sf /usr/bin/clang-format-18 /usr/local/bin/clang-format \
+    clang \
+    clang-tidy \
+    clang-format \
     && rm -rf /var/lib/apt/lists/*
 
 # devuser for local development

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -1,27 +1,32 @@
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
 # Bypass interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update and install dependencies necessary for the Claude CLI as well as
 # building/testing the underlying C++ Crow application in this repository.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    g++ \
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
     git \
     gh \
-    make \
-    cmake \
+    curl \
+    ca-certificates \
+    sudo \
+    libssl-dev \
+    libboost-dev \
+    libcurl4-openssl-dev \
     libasio-dev \
-    libpq-dev \
+    libsqlite3-dev \
+    clang \
+    clang-tidy \
+    clang-format \
     openssh-client \
     unzip \
     nodejs \
     npm \
     python3 \
     jq \
-    sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Anthropic's Claude CLI


### PR DESCRIPTION
Ubuntu 24.04 ships clang-18 in the default apt repos, so the LLVM
third-party PPA (and the gnupg/lsb-release/curl setup required for it)
is no longer needed in Dockerfile or clang-lint.yml. All GitHub runner
jobs updated from ubuntu-22.04 to ubuntu-24.04.

https://claude.ai/code/session_01W5zJjKR9JQWfekNadgVhUN