### PR TITLE
Split lintenator.sh into separate clang-tidy and clang-format scripts

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,26 @@
+name: clang-format
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Run clang-format
+        run: |
+          chmod +x scripts/clang-format.sh
+          ./scripts/clang-format.sh

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-name: clang lint
+name: clang-tidy
 
 on:
   pull_request:
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  lintenator:
-    name: lintenator (clang-tidy + clang-format)
+  clang-tidy:
+    name: clang-tidy
     runs-on: ubuntu-24.04
 
     steps:
@@ -27,8 +27,7 @@ jobs:
             libcurl4-openssl-dev \
             libsqlite3-dev \
             clang \
-            clang-tidy \
-            clang-format
+            clang-tidy
 
       - name: Cache CMake FetchContent
         uses: actions/cache@v4
@@ -45,7 +44,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_BUILD_TYPE=Debug
 
-      - name: Run lintenator
+      - name: Run clang-tidy
         run: |
-          chmod +x scripts/lintenator.sh
-          ./scripts/lintenator.sh --build-dir build
+          chmod +x scripts/clang-tidy.sh
+          ./scripts/clang-tidy.sh --build-dir build

--- a/Makefile
+++ b/Makefile
@@ -71,20 +71,28 @@ endif
 
 lint: build
 ifeq ($(LOCAL),1)
-	@echo "Running lintenator locally..."
-	./scripts/lintenator.sh --build-dir build
+	@echo "Running clang-tidy locally..."
+	./scripts/clang-tidy.sh --build-dir build
+	@echo "Running clang-format locally..."
+	./scripts/clang-format.sh
 else
-	@echo "Running lintenator (clang-tidy + clang-format) inside container..."
-	docker exec meal_prep_dev bash -c "cd /home/devuser/meal_prep && ./scripts/lintenator.sh --build-dir build_docker"
+	@echo "Running clang-tidy inside container..."
+	docker exec meal_prep_dev bash -c "cd /home/devuser/meal_prep && ./scripts/clang-tidy.sh --build-dir build_docker"
+	@echo "Running clang-format inside container..."
+	docker exec meal_prep_dev bash -c "cd /home/devuser/meal_prep && ./scripts/clang-format.sh"
 endif
 
 lint-fix: build
 ifeq ($(LOCAL),1)
-	@echo "Running lintenator with --fix locally..."
-	./scripts/lintenator.sh --build-dir build --fix
+	@echo "Running clang-tidy with --fix locally..."
+	./scripts/clang-tidy.sh --build-dir build --fix
+	@echo "Running clang-format with --fix locally..."
+	./scripts/clang-format.sh --fix
 else
-	@echo "Running lintenator with --fix inside container..."
-	docker exec meal_prep_dev bash -c "cd /home/devuser/meal_prep && ./scripts/lintenator.sh --build-dir build_docker --fix"
+	@echo "Running clang-tidy with --fix inside container..."
+	docker exec meal_prep_dev bash -c "cd /home/devuser/meal_prep && ./scripts/clang-tidy.sh --build-dir build_docker --fix"
+	@echo "Running clang-format with --fix inside container..."
+	docker exec meal_prep_dev bash -c "cd /home/devuser/meal_prep && ./scripts/clang-format.sh --fix"
 endif
 
 asan:

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# clang-format.sh — runs clang-format checks on project sources.
+#
+# Usage:
+#   ./scripts/clang-format.sh [--fix]
+#
+# Options:
+#   --fix   Apply clang-format fixes automatically (default: check only)
+#
+# Exit codes:
+#   0  All checks passed
+#   1  One or more checks failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+FIX_MODE=false
+ERRORS=0
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix)
+      FIX_MODE=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Source files to format (project sources only, excluding third-party)
+PROJECT_SOURCES=(
+  src/db_manager.cpp
+  src/meal_factory.cpp
+  src/email_service.cpp
+  src/meal_planner.cpp
+  src/api_routes.cpp
+  src/config_parser.cpp
+  src/google_oauth.cpp
+  src/calendar_service.cpp
+  src/token_encryption.cpp
+  src/main.cpp
+  tests/test_ingredient.cpp
+  tests/test_meal.cpp
+  tests/test_meal_factory.cpp
+  tests/test_measurement.cpp
+  tests/test_meal_planner.cpp
+)
+
+echo "============================================"
+echo " Running clang-format"
+echo "============================================"
+
+FORMAT_SOURCES=()
+for src in "${PROJECT_SOURCES[@]}"; do
+  full_path="${PROJECT_ROOT}/${src}"
+  [[ -f "${full_path}" ]] && FORMAT_SOURCES+=("${full_path}")
+done
+
+# Also include header files
+while IFS= read -r -d '' hdr; do
+  FORMAT_SOURCES+=("${hdr}")
+done < <(find "${PROJECT_ROOT}/src" -maxdepth 1 -name '*.h' -print0)
+
+if $FIX_MODE; then
+  echo "  Applying clang-format..."
+  clang-format -i "${FORMAT_SOURCES[@]}"
+  echo "  Done."
+else
+  echo "  Checking formatting..."
+  for f in "${FORMAT_SOURCES[@]}"; do
+    rel="${f#"${PROJECT_ROOT}/"}"
+    if ! clang-format --dry-run --Werror "${f}" 2>/dev/null; then
+      echo "  [FAIL] ${rel} — formatting issue (run with --fix to auto-correct)"
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+  if [[ "${ERRORS}" -eq 0 ]]; then
+    echo "  All files correctly formatted."
+  fi
+fi
+
+echo ""
+echo "============================================"
+if [[ "${ERRORS}" -eq 0 ]]; then
+  echo " clang-format: all checks passed"
+  echo "============================================"
+  exit 0
+else
+  echo " clang-format: ${ERRORS} check(s) failed"
+  echo "============================================"
+  exit 1
+fi

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# lintenator.sh — runs clang-tidy and clang-format checks on project sources.
+# clang-tidy.sh — runs clang-tidy checks on project sources.
 #
 # Usage:
-#   ./scripts/lintenator.sh [--build-dir <dir>] [--fix]
+#   ./scripts/clang-tidy.sh [--build-dir <dir>] [--fix]
 #
 # Options:
 #   --build-dir <dir>   Directory containing compile_commands.json (default: build)
@@ -47,7 +47,7 @@ if [[ ! -f "${COMPILE_COMMANDS}" ]]; then
   exit 1
 fi
 
-# Source files to lint (project sources only, excluding third-party)
+# Source files to check (project sources only, excluding third-party)
 PROJECT_SOURCES=(
   src/db_manager.cpp
   src/meal_factory.cpp
@@ -66,7 +66,6 @@ PROJECT_SOURCES=(
   tests/test_meal_planner.cpp
 )
 
-# ── clang-tidy ────────────────────────────────────────────────────────────────
 echo "============================================"
 echo " Running clang-tidy"
 echo "============================================"
@@ -91,53 +90,14 @@ for src in "${PROJECT_SOURCES[@]}"; do
   fi
 done
 
-# ── clang-format ──────────────────────────────────────────────────────────────
-echo ""
-echo "============================================"
-echo " Running clang-format"
-echo "============================================"
-
-FORMAT_SOURCES=()
-for src in "${PROJECT_SOURCES[@]}"; do
-  full_path="${PROJECT_ROOT}/${src}"
-  [[ -f "${full_path}" ]] && FORMAT_SOURCES+=("${full_path}")
-done
-
-# Also include header files
-while IFS= read -r -d '' hdr; do
-  FORMAT_SOURCES+=("${hdr}")
-done < <(find "${PROJECT_ROOT}/src" -maxdepth 1 -name '*.h' -print0)
-
-if $FIX_MODE; then
-  echo "  Applying clang-format..."
-  clang-format -i "${FORMAT_SOURCES[@]}"
-  echo "  Done."
-else
-  echo "  Checking formatting..."
-  FORMAT_ERRORS=0
-  for f in "${FORMAT_SOURCES[@]}"; do
-    rel="${f#"${PROJECT_ROOT}/"}"
-    if ! clang-format --dry-run --Werror "${f}" 2>/dev/null; then
-      echo "  [FAIL] ${rel} — formatting issue (run with --fix to auto-correct)"
-      FORMAT_ERRORS=$((FORMAT_ERRORS + 1))
-    fi
-  done
-  if [[ "${FORMAT_ERRORS}" -eq 0 ]]; then
-    echo "  All files correctly formatted."
-  else
-    ERRORS=$((ERRORS + FORMAT_ERRORS))
-  fi
-fi
-
-# ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "============================================"
 if [[ "${ERRORS}" -eq 0 ]]; then
-  echo " lintenator: all checks passed"
+  echo " clang-tidy: all checks passed"
   echo "============================================"
   exit 0
 else
-  echo " lintenator: ${ERRORS} check(s) failed"
+  echo " clang-tidy: ${ERRORS} check(s) failed"
   echo "============================================"
   exit 1
 fi


### PR DESCRIPTION
Replace the single lintenator.sh with clang-tidy.sh and clang-format.sh, and update GitHub workflows to two separate jobs so clang-format can run without a full CMake configure step.