### PR TITLE
Consolidate Claude credentials into ~/.claude_config

### DIFF
--- a/run_claude.sh
+++ b/run_claude.sh
@@ -3,14 +3,15 @@
 CONTAINER_NAME="claude-workspace"
 DOTFILES_REPO="git@github.com:JohnnyJ5/dotfiles.git"
 DOTFILES_DIR=".claude_workspace_env/dotfiles"
+CLAUDE_CONFIG_DIR="$HOME/.claude_config"
 
-if [ -f "$HOME/.config/gh/gh_token" ]; then
-    GH_TOKEN_VALUE=$(cat "$HOME/.config/gh/gh_token")
+if [ -f "$CLAUDE_CONFIG_DIR/gh_token" ]; then
+    GH_TOKEN_VALUE=$(cat "$CLAUDE_CONFIG_DIR/gh_token")
 elif [ -n "$GH_TOKEN" ]; then
     GH_TOKEN_VALUE="$GH_TOKEN"
 else
     echo "WARNING: No GH_TOKEN found. gh commands will not be authenticated."
-    echo "  Fix: echo 'ghp_yourtoken' > ~/.config/gh/gh_token && chmod 600 ~/.config/gh/gh_token"
+    echo "  Fix: echo 'ghp_yourtoken' > ~/.claude_config/gh_token && chmod 600 ~/.claude_config/gh_token"
     GH_TOKEN_VALUE=""
 fi
 
@@ -19,7 +20,7 @@ DOCKER_COMMON=(
     -e GIT_SSH_COMMAND="ssh -i /app/.claude_workspace_env/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
     -e GH_TOKEN="${GH_TOKEN_VALUE}"
     -v "$(pwd)":/app
-    -v "$HOME/.ssh/claude_github:/app/.claude_workspace_env/.ssh/id_ed25519:ro"
+    -v "$CLAUDE_CONFIG_DIR/ssh/id_ed25519:/app/.claude_workspace_env/.ssh/id_ed25519:ro"
 )
 
 dotfiles() {
@@ -51,8 +52,8 @@ if [ "$(docker ps -q -f name=^${CONTAINER_NAME}$)" ]; then
 else
     echo "Starting a new '${CONTAINER_NAME}' container..."
 
-    if [ ! -f "$HOME/.ssh/claude_github" ]; then
-        echo "ERROR: SSH key not found at ~/.ssh/claude_github"
+    if [ ! -f "$CLAUDE_CONFIG_DIR/ssh/id_ed25519" ]; then
+        echo "ERROR: SSH key not found at ~/.claude_config/ssh/id_ed25519"
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

- Moves SSH key lookup from `~/.ssh/claude_github` to `~/.claude_config/ssh/id_ed25519`
- Moves GH token lookup from `~/.config/gh/gh_token` to `~/.claude_config/gh_token`
- Introduces `CLAUDE_CONFIG_DIR` variable in `run_claude.sh` so the path is defined once

## Migration

Existing setups need a one-time file move:
```bash
mkdir -p ~/.claude_config/ssh
mv ~/.ssh/claude_github ~/.claude_config/ssh/id_ed25519
mv ~/.config/gh/gh_token ~/.claude_config/gh_token
chmod 600 ~/.claude_config/ssh/id_ed25519 ~/.claude_config/gh_token
```

## Test plan
- [ ] Run `./run_claude.sh` with credentials in the new location — container starts and gh is authenticated
- [ ] Verify SSH-based git operations work inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)