### PR TITLE
Fix Docker UID/GID mismatch between host user and container claude user

### DIFF
--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y \
     python3 \
     jq \
     vim \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Anthropic's Claude CLI
@@ -44,11 +45,14 @@ RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >> /etc/bash.bashrc
 RUN useradd -m -s /bin/bash claude && \
     echo "claude ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Switch to the non-root user
-USER claude
+# Copy and install the entrypoint that remaps claude's UID/GID at runtime
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# Stay as root so the entrypoint can call usermod/groupmod before dropping to claude
 # Set the working directory where the repository should be mounted
 WORKDIR /app
 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 # Ensure we have a default command that drops the user into an interactive shell
 CMD ["/bin/bash"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+# If HOST_UID/HOST_GID are provided, remap the 'claude' user to match the
+# host user that owns the mounted volume. This prevents permission mismatches
+# when run_claude.sh creates files on the host and places them in the mount.
+if [ -n "${HOST_UID}" ] && [ "${HOST_UID}" != "$(id -u claude)" ]; then
+    usermod -u "${HOST_UID}" claude
+fi
+
+if [ -n "${HOST_GID}" ] && [ "${HOST_GID}" != "$(id -g claude)" ]; then
+    groupmod -g "${HOST_GID}" claude
+fi
+
+exec gosu claude "$@"

--- a/run_claude.sh
+++ b/run_claude.sh
@@ -19,6 +19,8 @@ DOCKER_COMMON=(
     -e HOME=/app/.claude_workspace_env
     -e GIT_SSH_COMMAND="ssh -i /app/.claude_workspace_env/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
     -e GH_TOKEN="${GH_TOKEN_VALUE}"
+    -e HOST_UID="$(id -u)"
+    -e HOST_GID="$(id -g)"
     -v "$(pwd)":/app
     -v "$CLAUDE_CONFIG_DIR/ssh/id_ed25519:/app/.claude_workspace_env/.ssh/id_ed25519:ro"
 )


### PR DESCRIPTION
Adds an entrypoint.sh that calls usermod/groupmod at container startup to
remap the 'claude' user's UID/GID to HOST_UID/HOST_GID, which are passed
from run_claude.sh via $(id -u)/$(id -g). This ensures files created on
the host by run_claude.sh and placed in the mounted volume are accessible
to the claude user inside the container without permission errors.

https://claude.ai/code/session_01CTQabDkp3BSGExJjP2531s