### PR TITLE
Fix UID collision when host user has UID 1000

### DIFF
--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -41,6 +41,11 @@ RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >> /etc/bash.bashrc
 # GH_TOKEN is read automatically by `gh` — pass it at runtime via --env or docker-compose.
 # No credentials are baked into the image; the variable just needs to be present at runtime.
 
+# ubuntu:24.04 ships with an 'ubuntu' user at UID/GID 1000. Move it out of the
+# way so that 'claude' can claim UID 1000 and the entrypoint's usermod can
+# remap to any host UID without hitting a collision.
+RUN usermod -u 999 ubuntu 2>/dev/null || true
+
 # Create a non-root user to run Claude (with sudo privileges just in case)
 RUN useradd -m -s /bin/bash claude && \
     echo "claude ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,10 +5,21 @@ set -e
 # host user that owns the mounted volume. This prevents permission mismatches
 # when run_claude.sh creates files on the host and places them in the mount.
 if [ -n "${HOST_UID}" ] && [ "${HOST_UID}" != "$(id -u claude)" ]; then
+    # If another user already owns the target UID (e.g. the 'ubuntu' user
+    # pre-installed in ubuntu:24.04), bump it out of the way first.
+    conflicting_user=$(getent passwd "${HOST_UID}" | cut -d: -f1 || true)
+    if [ -n "$conflicting_user" ] && [ "$conflicting_user" != "claude" ]; then
+        usermod -u 65534 "$conflicting_user"
+    fi
     usermod -u "${HOST_UID}" claude
 fi
 
 if [ -n "${HOST_GID}" ] && [ "${HOST_GID}" != "$(id -g claude)" ]; then
+    # Same treatment for GID conflicts.
+    conflicting_group=$(getent group "${HOST_GID}" | cut -d: -f1 || true)
+    if [ -n "$conflicting_group" ] && [ "$conflicting_group" != "claude" ]; then
+        groupmod -g 65534 "$conflicting_group"
+    fi
     groupmod -g "${HOST_GID}" claude
 fi
 


### PR DESCRIPTION
ubuntu:24.04 includes a pre-built 'ubuntu' user at UID 1000. When the
invoking host user also has UID 1000, the entrypoint's usermod call fails
with "UID already in use".

Two-pronged fix:
- Dockerfile.claude: relocate the ubuntu user to UID 999 at build time so
  'claude' can be created at UID 1000 and the common case (host UID == 1000)
  requires no remapping at all.
- entrypoint.sh: for any host UID, detect and evict a conflicting user/group
  to UID/GID 65534 (nobody) before calling usermod/groupmod on claude.

https://claude.ai/code/session_01DoNuNqP9BwMLB5JSRtVk9S