### PR TITLE
Add db-dump-job to Cloud Build pipeline

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,5 +30,33 @@ steps:
       - '--update-secrets'
       - '/secrets_calendar/calendar_credentials.json=calendar-credentials:latest'
 
+  # 4. Build the db-dump-job image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/db-dump-job', '-f', 'db_job/Dockerfile.job', 'db_job']
+
+  # 5. Push the db-dump-job image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/db-dump-job']
+
+  # 6. Deploy the db-dump-job Cloud Run Job
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'jobs'
+      - 'deploy'
+      - 'db-dump-job'
+      - '--image'
+      - 'gcr.io/$PROJECT_ID/db-dump-job'
+      - '--region'
+      - 'us-central1'
+      - '--set-env-vars'
+      - 'DB_PATH=/mnt/db/meals.db'
+      - '--add-volume'
+      - 'name=db-volume,type=cloud-storage,bucket=meal-prep-db-bucket'
+      - '--add-volume-mount'
+      - 'volume=db-volume,mount-path=/mnt/db'
+
 images:
   - 'gcr.io/$PROJECT_ID/meal-prep'
+  - 'gcr.io/$PROJECT_ID/db-dump-job'


### PR DESCRIPTION
The db_job image was never rebuilt by Cloud Build, so changes to
dump_db.py (like the DB_PATH env var support) never made it into
the deployed Cloud Run Job. This adds build/push/deploy steps for
the db-dump-job alongside the existing meal-prep service steps.

https://claude.ai/code/session_01F55kwwNYC6N7VfVqVYaCjX