### PR TITLE
Fix Cloud Build failure: remove copy of gitignored meal_prep.conf.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ WORKDIR /home/appuser/app
 # Copy binary from build stage
 COPY --from=build-env --chown=appuser:appuser /home/devuser/meal_prep/build_docker/meal_prep .
 COPY --from=build-env --chown=appuser:appuser /home/devuser/meal_prep/static ./static
-COPY --from=build-env --chown=appuser:appuser /home/devuser/meal_prep/meal_prep.conf.json .
 
 USER appuser
 


### PR DESCRIPTION
meal_prep.conf.json is in .gitignore so it doesn't exist when Cloud
Build checks out the repo. The Dockerfile was trying to COPY it from
the build stage, causing a "file not found" error and breaking every
build.

The config_parser already handles a missing config file gracefully —
DB_PATH, PORT, and GOOGLE_REDIRECT_URI are all read from env vars, and
the calendar credentials fall back to /secrets_calendar/calendar_credentials.json.

https://claude.ai/code/session_017fC1qZrJhG3JBxCD9gCSoh