### PR TITLE
Show meal ID in manage meal dialog

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,5 @@ IndentWidth: 4
 ColumnLimit: 100
 UseTab: Never
 TabWidth: 4
+IncludeBlocks: Preserve
 ---

--- a/src/api_routes.cpp
+++ b/src/api_routes.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <tuple>
 
 #include "meal_planner.h"
 
@@ -12,12 +13,13 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
     // Route: Get all available meals
     CROW_ROUTE(app, "/api/meals")
     ([&factory]() {
-        std::vector<std::pair<std::string, std::string>> meals;
+        std::vector<std::tuple<int, std::string, std::string>> meals;
         factory.getAvailableMeals(meals);
         crow::json::wvalue res;
         for (size_t i = 0; i < meals.size(); ++i) {
-            res[i]["name"] = meals[i].first;
-            res[i]["category"] = meals[i].second;
+            res[i]["id"] = std::get<0>(meals[i]);
+            res[i]["name"] = std::get<1>(meals[i]);
+            res[i]["category"] = std::get<2>(meals[i]);
         }
         CROW_LOG_INFO << "Successfully retrieved " << meals.size() << " available meals";
         return res;

--- a/src/db_manager.cpp
+++ b/src/db_manager.cpp
@@ -301,22 +301,23 @@ std::unique_ptr<Meal> DBManager::getMeal(const std::string &mealName) {
     return std::make_unique<Meal>(mealName, ingredients, category);
 }
 
-bool DBManager::getAllMeals(std::vector<std::pair<std::string, std::string>> &meals) {
+bool DBManager::getAllMeals(std::vector<std::tuple<int, std::string, std::string>> &meals) {
     std::lock_guard<std::recursive_mutex> lock(d_mutex);
     if (!d_db) return false;
 
-    std::string query = "SELECT name, category FROM meals ORDER BY name ASC;";
+    std::string query = "SELECT id, name, category FROM meals ORDER BY name ASC;";
     sqlite3_stmt *stmt = nullptr;
 
     if (sqlite3_prepare_v2(d_db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
         while (sqlite3_step(stmt) == SQLITE_ROW) {
-            std::string name = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0));
+            int id = sqlite3_column_int(stmt, 0);
+            std::string name = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 1));
             std::string category = "Uncategorized";
             if (const char *catText =
-                    reinterpret_cast<const char *>(sqlite3_column_text(stmt, 1))) {
+                    reinterpret_cast<const char *>(sqlite3_column_text(stmt, 2))) {
                 category = catText;
             }
-            meals.emplace_back(name, category);
+            meals.emplace_back(id, name, category);
         }
     }
     sqlite3_finalize(stmt);
@@ -453,7 +454,7 @@ bool DBManager::seedDefaultIngredients() {
 bool DBManager::seedDefaultMeals() {
     std::lock_guard<std::recursive_mutex> lock(d_mutex);
     // This will seed the database with the initial hardcoded values if empty.
-    std::vector<std::pair<std::string, std::string>> existing;
+    std::vector<std::tuple<int, std::string, std::string>> existing;
     getAllMeals(existing);
     if (!existing.empty()) return true;  // Already seeded
 

--- a/src/db_manager.h
+++ b/src/db_manager.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "meal.h"
@@ -90,12 +91,12 @@ class DBManager {
     std::unique_ptr<Meal> getMeal(const std::string &mealName);
 
     /**
-     * @brief Retrieves a list of all available meal names and categories from the
-     * database.
-     * @param meals Vector to populate with pairs of meal names and categories.
+     * @brief Retrieves a list of all available meal ids, names, and categories
+     * from the database.
+     * @param meals Vector to populate with tuples of (id, name, category).
      * @return true if successful, false otherwise.
      */
-    bool getAllMeals(std::vector<std::pair<std::string, std::string>> &meals);
+    bool getAllMeals(std::vector<std::tuple<int, std::string, std::string>> &meals);
 
     /**
      * @brief Saves Google OAuth2 tokens to the database.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "api_routes.h"
@@ -68,10 +69,11 @@ int main(int argc, char **argv) {
 
         if (listMeals) {
             std::cout << "Available meals:" << std::endl;
-            std::vector<std::pair<std::string, std::string>> meals;
+            std::vector<std::tuple<int, std::string, std::string>> meals;
             factory.getAvailableMeals(meals);
-            for (const auto &mealPair : meals) {
-                std::cout << "-m " << mealPair.first << " [" << mealPair.second << "]" << std::endl;
+            for (const auto &mealTuple : meals) {
+                std::cout << "-m " << std::get<1>(mealTuple) << " [" << std::get<2>(mealTuple)
+                          << "]" << std::endl;
             }
             return 0;
         }

--- a/src/meal_factory.cpp
+++ b/src/meal_factory.cpp
@@ -1,6 +1,7 @@
 #include "meal_factory.h"
 
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -20,7 +21,7 @@ std::unique_ptr<Meal> MealFactory::createMeal(const std::string &mealName) {
 }
 
 // Function to get all available meal names and categories
-void MealFactory::getAvailableMeals(std::vector<std::pair<std::string, std::string>> &meals) {
+void MealFactory::getAvailableMeals(std::vector<std::tuple<int, std::string, std::string>> &meals) {
     if (d_dbManager) {
         d_dbManager->getAllMeals(meals);
     }

--- a/src/meal_factory.h
+++ b/src/meal_factory.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -33,7 +34,7 @@ class MealFactory {
      * meals.
      * @param meals The vector to populate.
      */
-    void getAvailableMeals(std::vector<std::pair<std::string, std::string>> &meals);
+    void getAvailableMeals(std::vector<std::tuple<int, std::string, std::string>> &meals);
 
    private:
     std::shared_ptr<DBManager> d_dbManager;

--- a/static/script.js
+++ b/static/script.js
@@ -574,6 +574,7 @@ async function fetchManageMeals() {
                     <strong>${formatName(mealId)}</strong>
                     <span class="badge" style="margin-left:8px; font-size:0.8rem; background:var(--primary-color); padding:2px 6px; border-radius:4px; color:white;">${meal.category}</span>
                     <br><small style="color: var(--text-secondary);">${mealId}</small>
+                    <br><small style="color: var(--text-secondary);">ID: ${meal.id}</small>
                 </div>
                 <div class="manage-item-actions">
                     <button class="btn btn-secondary btn-sm" onclick="editMeal('${mealId}')">Edit</button>

--- a/tests/test_db_manager.cpp
+++ b/tests/test_db_manager.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
+#include <tuple>
 
 #include "../src/db_manager.h"
 #include "../src/ingredient.h"
@@ -79,16 +80,16 @@ TEST_F(DBManagerTest, GetAllMealsReturnsAllEntries) {
     db->addMeal(makeMeal("meal-b", "Cat2"));
     db->addMeal(makeMeal("meal-a", "Cat1"));
 
-    std::vector<std::pair<std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string>> meals;
     EXPECT_TRUE(db->getAllMeals(meals));
     ASSERT_EQ(meals.size(), 2u);
-    EXPECT_EQ(meals[0].first, "meal-a");  // ordered ASC
-    EXPECT_EQ(meals[1].first, "meal-b");
+    EXPECT_EQ(std::get<1>(meals[0]), "meal-a");  // ordered ASC
+    EXPECT_EQ(std::get<1>(meals[1]), "meal-b");
 }
 
 // getAllMeals on empty DB returns empty vector
 TEST_F(DBManagerTest, GetAllMealsEmptyDB) {
-    std::vector<std::pair<std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string>> meals;
     EXPECT_TRUE(db->getAllMeals(meals));
     EXPECT_TRUE(meals.empty());
 }
@@ -144,7 +145,7 @@ TEST_F(DBManagerTest, SeedDefaultIngredientsIsIdempotent) {
 TEST_F(DBManagerTest, SeedDefaultMealsPopulatesTable) {
     EXPECT_TRUE(db->seedDefaultMeals());
 
-    std::vector<std::pair<std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string>> meals;
     db->getAllMeals(meals);
     EXPECT_GT(meals.size(), 0u);
 }
@@ -152,11 +153,11 @@ TEST_F(DBManagerTest, SeedDefaultMealsPopulatesTable) {
 // seedDefaultMeals is idempotent
 TEST_F(DBManagerTest, SeedDefaultMealsIsIdempotent) {
     db->seedDefaultMeals();
-    std::vector<std::pair<std::string, std::string>> first;
+    std::vector<std::tuple<int, std::string, std::string>> first;
     db->getAllMeals(first);
 
     db->seedDefaultMeals();
-    std::vector<std::pair<std::string, std::string>> second;
+    std::vector<std::tuple<int, std::string, std::string>> second;
     db->getAllMeals(second);
 
     EXPECT_EQ(first.size(), second.size());

--- a/tests/test_meal_factory.cpp
+++ b/tests/test_meal_factory.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <tuple>
+
 #include "../src/db_manager.h"
 #include "../src/meal.h"
 #include "../src/meal_factory.h"
@@ -47,7 +49,7 @@ TEST_F(MealFactoryTest, CaseSensitivity) {
 
 // Test getAvailableMeals
 TEST_F(MealFactoryTest, GetAvailableMeals) {
-    std::vector<std::pair<std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string>> meals;
     factory->getAvailableMeals(meals);
 
     EXPECT_GT(meals.size(), 0);
@@ -56,11 +58,11 @@ TEST_F(MealFactoryTest, GetAvailableMeals) {
     bool hasTurkeyBurgers = false;
     bool hasChickenStirFry = false;
 
-    for (const auto &mealPair : meals) {
-        if (mealPair.first == "turkey-burgers") {
+    for (const auto &mealTuple : meals) {
+        if (std::get<1>(mealTuple) == "turkey-burgers") {
             hasTurkeyBurgers = true;
         }
-        if (mealPair.first == "chicken-stir-fry") {
+        if (std::get<1>(mealTuple) == "chicken-stir-fry") {
             hasChickenStirFry = true;
         }
     }
@@ -71,12 +73,12 @@ TEST_F(MealFactoryTest, GetAvailableMeals) {
 
 // Test that all available meals can be creatable
 TEST_F(MealFactoryTest, AllAvailableMealsAreCreatable) {
-    std::vector<std::pair<std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string>> meals;
     factory->getAvailableMeals(meals);
 
-    for (const auto &mealPair : meals) {
-        auto meal = factory->createMeal(mealPair.first);
-        EXPECT_NE(meal, nullptr) << "Failed to create meal: " << mealPair.first;
+    for (const auto &mealTuple : meals) {
+        auto meal = factory->createMeal(std::get<1>(mealTuple));
+        EXPECT_NE(meal, nullptr) << "Failed to create meal: " << std::get<1>(mealTuple);
         if (meal) {
             EXPECT_FALSE(meal->getName().empty());
             EXPECT_FALSE(meal->getCategory().empty());


### PR DESCRIPTION
Adds the numeric database ID below the kebab-case name in each row of
the manage meals list. Threads the id through getAllMeals (db_manager),
getAvailableMeals (meal_factory), and the /api/meals JSON response using
tuple<int,string,string> instead of pair<string,string>.

https://claude.ai/code/session_01SnLPy8asfWFTrNRf9exrGa