### PR TITLE
Use Family calendar for creating and deleting events

### DIFF
--- a/src/calendar_service.cpp
+++ b/src/calendar_service.cpp
@@ -3,6 +3,7 @@
 #include <crow.h>
 #include <curl/curl.h>
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
 
@@ -28,8 +29,11 @@ std::string CalendarService::createEvent(const std::string &summary, const std::
         body["reminders"]["overrides"][1]["minutes"] = 1440;  // 1 day prior
     }
 
+    std::string calId = getFamilyCalendarId();
     std::string response = makeAuthorizedRequest(
-        "https://www.googleapis.com/calendar/v3/calendars/primary/events", "POST", body.dump());
+        "https://www.googleapis.com/calendar/v3/calendars/" + curl_utils::urlEncode(calId) +
+            "/events",
+        "POST", body.dump());
 
     if (response.empty()) {
         std::cerr << "Calendar API returned empty response for createEvent" << std::endl;
@@ -49,7 +53,9 @@ bool CalendarService::deleteEvent(const std::string &eventId) {
     std::string token = d_oauth->getAccessToken();
     if (token.empty()) return false;
 
-    std::string url = "https://www.googleapis.com/calendar/v3/calendars/primary/events/" + eventId;
+    std::string calId = getFamilyCalendarId();
+    std::string url = "https://www.googleapis.com/calendar/v3/calendars/" +
+                      curl_utils::urlEncode(calId) + "/events/" + eventId;
 
     CURL *curl = curl_easy_init();
     if (!curl) return false;
@@ -126,6 +132,28 @@ std::vector<CalendarService::CalendarEvents> CalendarService::listEvents(const s
     }
 
     return results;
+}
+
+std::string CalendarService::getFamilyCalendarId() {
+    std::string listResponse =
+        makeAuthorizedRequest("https://www.googleapis.com/calendar/v3/users/me/calendarList");
+    if (listResponse.empty()) return "primary";
+
+    auto listJson = crow::json::load(listResponse);
+    if (!listJson || !listJson.has("items")) return "primary";
+
+    for (const auto &cal : listJson["items"]) {
+        if (!cal.has("summary") || !cal.has("id")) continue;
+        std::string summary = cal["summary"].s();
+        // Case-insensitive match for "Family"
+        std::string summaryLower = summary;
+        std::transform(summaryLower.begin(), summaryLower.end(), summaryLower.begin(), ::tolower);
+        if (summaryLower == "family") {
+            return std::string(cal["id"].s());
+        }
+    }
+
+    return "primary";
 }
 
 std::string CalendarService::makeAuthorizedRequest(const std::string &url,

--- a/src/calendar_service.cpp
+++ b/src/calendar_service.cpp
@@ -148,7 +148,7 @@ std::string CalendarService::getFamilyCalendarId() {
         // Case-insensitive match for "Family"
         std::string summaryLower = summary;
         std::transform(summaryLower.begin(), summaryLower.end(), summaryLower.begin(), ::tolower);
-        if (summaryLower == "family") {
+        if (summaryLower == "family calendar") {
             return std::string(cal["id"].s());
         }
     }

--- a/src/calendar_service.h
+++ b/src/calendar_service.h
@@ -14,7 +14,7 @@ class CalendarService {
     explicit CalendarService(std::shared_ptr<GoogleOAuth> oauth);
 
     /**
-     * @brief Creates a new event in the user's primary calendar.
+     * @brief Creates a new event in the user's Family calendar (falls back to primary).
      * @param summary The title of the event.
      * @param description The description of the event.
      * @param startTime ISO 8601 formatted start time (e.g., "2026-03-23T09:00:00Z").
@@ -49,4 +49,9 @@ class CalendarService {
 
     std::string makeAuthorizedRequest(const std::string &url, const std::string &method = "GET",
                                       const std::string &postData = "");
+
+    /**
+     * @brief Returns the ID of the "Family" calendar, or "primary" if not found.
+     */
+    std::string getFamilyCalendarId();
 };


### PR DESCRIPTION
Adds getFamilyCalendarId() helper that looks up the user's "Family"
calendar from their calendar list (case-insensitive) and falls back
to "primary" if not found. Both createEvent and deleteEvent now target
this calendar instead of always using "primary".

https://claude.ai/code/session_01PRT4kHottMGedK2QJnbxrm