### PR TITLE
Fix meal cards appearing slowly when expanding categories

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -85,8 +85,8 @@ function renderMeals(meals) {
         grouped[cat].push(meal.name);
     });
 
-    let index = 0;
     for (const [category, mealNames] of Object.entries(grouped)) {
+        let index = 0;
         const header = document.createElement('h3');
         header.className = 'category-header collapsed';
         header.innerHTML = `<span class="category-chevron">&#9654;</span> ${category}`;


### PR DESCRIPTION
Animation delay index was global across all categories, so cards in
later categories had delays of 2s+ before fading in. Reset index per
category so each category's cards animate in starting from 0ms delay.

https://claude.ai/code/session_01DQvWqxwW6rTcv5toj619uA