### PR TITLE
Consolidate scattered action buttons in planner UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,3 +75,7 @@ CMake (C++17) with FetchContent for: Crow, Asio, GoogleTest. System deps: Boost,
 ## Cloud Deployment
 
 `cloudbuild.yaml` defines a 3-step pipeline: build image → push to Artifact Registry → deploy to Cloud Run. The GCS bucket `meal-prep-db-bucket` is mounted for persistent SQLite storage. Secrets for email/calendar credentials are injected via Cloud Secrets Manager. See `docs/GCP_COMMANDS.md` for deployment and database management commands.
+
+## Working with the UI
+
+When making any UI/frontend changes (HTML, CSS, JS in `static/`), always produce screenshot images of the result and attach them via `SendUserFile` so the user can see before/after visuals. This applies to every UI change, not just when explicitly requested.

--- a/static/index.html
+++ b/static/index.html
@@ -21,6 +21,7 @@
             </div>
         </div>
 
+        <div class="nav-section">Plan</div>
         <nav class="sidebar-nav">
             <div class="nav-item active">
                 <span class="nav-chev">▾</span>
@@ -32,27 +33,20 @@
                 <span class="nav-ico">▦</span>
                 <span>Manage Recipes</span>
             </button>
-            <button type="button" class="nav-item nav-item-btn" onclick="viewIngredients()">
-                <span class="nav-chev"></span>
-                <span class="nav-ico">▥</span>
-                <span>Grocery List</span>
-            </button>
         </nav>
 
-        <div class="nav-section">Workspaces</div>
-        <a class="nav-item" href="/auth/google">
+        <div class="nav-section">Integrations</div>
+        <a class="nav-item nav-item-stack" href="/auth/google" id="sidebar-calendar-link">
             <span class="nav-chev"></span>
             <span class="nav-ico">↗</span>
-            <span>Google Calendar</span>
+            <span class="nav-item-body">
+                <span>Google Calendar</span>
+                <span class="nav-item-meta" id="sidebar-calendar-meta">Checking…</span>
+            </span>
+            <span class="nav-status-dot" id="sidebar-calendar-dot" aria-hidden="true"></span>
         </a>
 
         <div class="sidebar-spacer"></div>
-
-        <div class="sidebar-cta">
-            <div class="cta-h">Ready to sync</div>
-            <div class="cta-s">Drop meals on the planner, then push the week to Google Calendar.</div>
-            <button type="button" class="cta-btn" onclick="planMeals()">Sync week</button>
-        </div>
     </aside>
 
     <main class="app-main">
@@ -65,13 +59,9 @@
                 <span id="week-label">This week</span>
             </div>
             <div class="topbar-r">
-                <a href="/auth/google" class="btn btn-google" id="link-calendar-btn">
-                    <img src="https://www.google.com/favicon.ico" width="14" height="14" alt="">
-                    Link Calendar
-                </a>
                 <div class="topbar-actions hidden" id="action-bar">
-                    <span class="selection-count"><b id="selected-count">0</b> selected</span>
-                    <button id="view-ingredients-btn" type="button" class="btn btn-secondary" onclick="viewIngredients()">
+                    <span class="selection-count" id="selection-chip" hidden><b id="selected-count">0</b> selected</span>
+                    <button id="view-ingredients-btn" type="button" class="btn btn-secondary" onclick="viewIngredients()" disabled>
                         View Ingredients
                     </button>
                     <button id="plan-btn" type="button" class="btn btn-primary" onclick="planMeals()" disabled>

--- a/static/script.js
+++ b/static/script.js
@@ -11,7 +11,36 @@ document.addEventListener('DOMContentLoaded', () => {
     fetchMeals();
     fetchIngredients();
     fetchCalendarEventsForWeek();
+    refreshCalendarLinkStatus();
 });
+
+async function refreshCalendarLinkStatus() {
+    const meta = document.getElementById('sidebar-calendar-meta');
+    const dot = document.getElementById('sidebar-calendar-dot');
+    const link = document.getElementById('sidebar-calendar-link');
+    if (!meta || !dot || !link) return;
+    try {
+        const probeStart = new Date();
+        const probeEnd = new Date(probeStart);
+        probeEnd.setDate(probeStart.getDate() + 1);
+        const url = `/api/calendar/events?timeMin=${encodeURIComponent(probeStart.toISOString())}&timeMax=${encodeURIComponent(probeEnd.toISOString())}`;
+        const response = await fetch(url);
+        if (response.ok) {
+            meta.textContent = 'Linked';
+            dot.classList.remove('is-unlinked');
+            dot.classList.add('is-linked');
+            link.setAttribute('title', 'Calendar linked — click to re-authenticate');
+        } else {
+            meta.textContent = 'Click to connect';
+            dot.classList.remove('is-linked');
+            dot.classList.add('is-unlinked');
+            link.setAttribute('title', 'Connect your Google Calendar');
+        }
+    } catch (e) {
+        meta.textContent = 'Click to connect';
+        dot.classList.add('is-unlinked');
+    }
+}
 
 let availableIngredients = [];
 
@@ -369,6 +398,7 @@ function attachDayTouchListeners(dayColEl) {
 
 function updateActionBar() {
     const countSpan = document.getElementById('selected-count');
+    const chip = document.getElementById('selection-chip');
     const planBtn = document.getElementById('plan-btn');
     const viewBtn = document.getElementById('view-ingredients-btn');
 
@@ -383,16 +413,16 @@ function updateActionBar() {
 
     const totalSelected = count + selectedMeals.size;
     countSpan.textContent = totalSelected;
+    if (chip) chip.hidden = totalSelected === 0;
 
     if (totalSelected > 0) {
         planBtn.removeAttribute('disabled');
-        if (selectedMeals.size > 0) {
-            viewBtn.removeAttribute('disabled');
-        } else {
-            viewBtn.setAttribute('disabled', 'true');
-        }
     } else {
         planBtn.setAttribute('disabled', 'true');
+    }
+    if (selectedMeals.size > 0) {
+        viewBtn.removeAttribute('disabled');
+    } else {
         viewBtn.setAttribute('disabled', 'true');
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -165,45 +165,47 @@ body {
     flex: 0 0 16px;
 }
 
+.nav-item-stack {
+    align-items: flex-start;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
+.nav-item-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    flex: 1;
+    min-width: 0;
+}
+
+.nav-item-meta {
+    font-size: 11px;
+    color: var(--ink-3);
+    font-weight: 400;
+}
+
+.nav-status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--ink-3);
+    flex: 0 0 7px;
+    margin-top: 5px;
+}
+
+.nav-status-dot.is-linked {
+    background: var(--success-color);
+    box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.14);
+}
+
+.nav-status-dot.is-unlinked {
+    background: var(--ink-3);
+}
+
 .sidebar-spacer {
     flex: 1;
     min-height: 24px;
-}
-
-.sidebar-cta {
-    margin-top: 12px;
-    border: 1px solid var(--line);
-    background: var(--paper);
-    border-radius: 10px;
-    padding: 12px;
-}
-
-.cta-h {
-    font-weight: 600;
-    font-size: 12.5px;
-    margin-bottom: 2px;
-}
-
-.cta-s {
-    font-size: 11.5px;
-    color: var(--ink-2);
-    margin-bottom: 10px;
-    line-height: 1.4;
-}
-
-.cta-btn {
-    width: 100%;
-    padding: 8px;
-    border: 0;
-    background: var(--ink);
-    color: white;
-    border-radius: 6px;
-    font: 600 12px var(--font-body);
-    cursor: pointer;
-}
-
-.cta-btn:hover {
-    background: var(--accent-color);
 }
 
 /* ── Main column ─────────────────────────────────────────────────────────── */
@@ -258,8 +260,15 @@ body {
 
 .topbar-actions .selection-count {
     font-size: 12px;
-    color: var(--ink-3);
-    padding-right: 6px;
+    color: var(--ink-2);
+    background: var(--bg-2);
+    border-radius: 999px;
+    padding: 4px 10px;
+    line-height: 1.2;
+}
+
+.topbar-actions .selection-count[hidden] {
+    display: none;
 }
 
 .topbar-actions .selection-count b {
@@ -1089,7 +1098,6 @@ h1 {
     .sidebar-nav,
     .nav-section,
     .sidebar-spacer,
-    .sidebar-cta,
     .app-sidebar > a.nav-item {
         display: none;
     }


### PR DESCRIPTION
Three actions were duplicated between the sidebar and topbar (Grocery
List/View Ingredients, Google Calendar/Link Calendar, Sync week/Generate
Plan), giving users no clear single place to act. This collapses the
buttons into two zones: navigation lives in the sidebar (Weekly Planner,
Manage Recipes, Google Calendar with live linked/unlinked status), and
the planning workflow lives in a single always-visible action group in
the topbar (selection chip → View Ingredients → Generate Plan).

Also adds a CLAUDE.md note that UI changes should ship with screenshots.

https://claude.ai/code/session_01NGzeWsbyfuXpcjH8HVcEmv