### PR TITLE
Add optional ingredients ("add-ons") to recipes

### DIFF
--- a/src/api_routes.cpp
+++ b/src/api_routes.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <set>
 #include <tuple>
 
 #include "meal_planner.h"
@@ -12,14 +13,17 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
                  const std::shared_ptr<CalendarService> &calendarService) {
     // Route: Get all available meals
     CROW_ROUTE(app, "/api/meals")
-    ([&factory]() {
+    ([&factory, &dbManager]() {
         std::vector<std::tuple<int, std::string, std::string>> meals;
         factory.getAvailableMeals(meals);
+        std::set<int> idsWithOptional = dbManager->getMealIdsWithOptionalIngredients();
         crow::json::wvalue res;
         for (size_t i = 0; i < meals.size(); ++i) {
-            res[i]["id"] = std::get<0>(meals[i]);
+            int id = std::get<0>(meals[i]);
+            res[i]["id"] = id;
             res[i]["name"] = std::get<1>(meals[i]);
             res[i]["category"] = std::get<2>(meals[i]);
+            res[i]["has_optional_ingredients"] = idsWithOptional.count(id) > 0;
         }
         CROW_LOG_INFO << "Successfully retrieved " << meals.size() << " available meals";
         return res;
@@ -88,9 +92,14 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
                     if (ingJson.has("preparation")) {
                         prep = ingJson["preparation"].s();
                     }
+                    bool isOptional = false;
+                    if (ingJson.has("optional")) {
+                        isOptional = ingJson["optional"].b();
+                    }
 
                     ingredients.emplace_back(
-                        ingName, Measurement(amount, static_cast<MeasurementUnit>(unit)), prep);
+                        ingName, Measurement(amount, static_cast<MeasurementUnit>(unit)), prep,
+                        isOptional);
                 }
 
                 std::string category = "Uncategorized";
@@ -139,9 +148,14 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
                         if (ingJson.has("preparation")) {
                             prep = ingJson["preparation"].s();
                         }
+                        bool isOptional = false;
+                        if (ingJson.has("optional")) {
+                            isOptional = ingJson["optional"].b();
+                        }
 
                         ingredients.emplace_back(
-                            ingName, Measurement(amount, static_cast<MeasurementUnit>(unit)), prep);
+                            ingName, Measurement(amount, static_cast<MeasurementUnit>(unit)), prep,
+                            isOptional);
                     }
 
                     std::string category = "Uncategorized";
@@ -192,6 +206,7 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
                     res["ingredients"][i]["amount"] = ing.getAmount().getValue();
                     res["ingredients"][i]["unit"] = static_cast<int>(ing.getAmount().getUnit());
                     res["ingredients"][i]["preparation"] = ing.getPreparation();
+                    res["ingredients"][i]["optional"] = ing.isOptional();
                 }
                 return crow::response(std::move(res));
             } else {
@@ -219,9 +234,23 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
             for (const auto &day : days) {
                 if (body.has(day)) {
                     for (const auto &mealJson : body[day]) {
-                        std::string mealName = mealJson.s();
+                        // Accept either a bare meal name string or
+                        // { "name": "...", "add_ons": ["..."] } for meals
+                        // that include selected optional ingredients.
+                        std::string mealName;
+                        std::set<std::string> addOns;
+                        if (mealJson.t() == crow::json::type::String) {
+                            mealName = mealJson.s();
+                        } else {
+                            mealName = mealJson["name"].s();
+                            if (mealJson.has("add_ons")) {
+                                for (const auto &a : mealJson["add_ons"]) {
+                                    addOns.insert(std::string(a.s()));
+                                }
+                            }
+                        }
                         schedule[day].push_back(mealName);
-                        if (auto meal = factory.createMeal(mealName)) {
+                        if (auto meal = factory.createMeal(mealName, addOns)) {
                             createdMeals.push_back(std::move(meal));
                         } else {
                             failedMeals.push_back(mealName);

--- a/src/db_manager.cpp
+++ b/src/db_manager.cpp
@@ -51,6 +51,7 @@ bool DBManager::initializeSchema() {
         "amount REAL NOT NULL, "
         "unit INTEGER NOT NULL, "
         "preparation TEXT NOT NULL, "
+        "is_optional INTEGER NOT NULL DEFAULT 0, "
         "FOREIGN KEY(meal_id) REFERENCES meals(id) ON DELETE CASCADE"
         ");";
 
@@ -94,6 +95,25 @@ bool DBManager::initializeSchema() {
     }
 
     if (!executeQuery(createIngredientsTable)) return false;
+
+    // Add is_optional column to existing ingredients tables if it doesn't exist
+    bool optionalColumnExists = false;
+    sqlite3_stmt *stmtIngCols = nullptr;
+    const std::string checkIngColumn = "PRAGMA table_info(ingredients);";
+    if (sqlite3_prepare_v2(d_db, checkIngColumn.c_str(), -1, &stmtIngCols, nullptr) == SQLITE_OK) {
+        while (sqlite3_step(stmtIngCols) == SQLITE_ROW) {
+            const char *colName =
+                reinterpret_cast<const char *>(sqlite3_column_text(stmtIngCols, 1));
+            if (colName && std::string(colName) == "is_optional") {
+                optionalColumnExists = true;
+                break;
+            }
+        }
+        sqlite3_finalize(stmtIngCols);
+    }
+    if (!optionalColumnExists) {
+        executeQuery("ALTER TABLE ingredients ADD COLUMN is_optional INTEGER NOT NULL DEFAULT 0;");
+    }
 
     if (!executeQuery(createAvailableIngredientsTable)) return false;
 
@@ -146,8 +166,8 @@ bool DBManager::addMeal(const Meal &meal) {
     int mealId = static_cast<int>(sqlite3_last_insert_rowid(d_db));
 
     std::string insertIngredient =
-        "INSERT INTO ingredients (meal_id, name, amount, unit, preparation) "
-        "VALUES (?, ?, ?, ?, ?);";
+        "INSERT INTO ingredients (meal_id, name, amount, unit, preparation, is_optional) "
+        "VALUES (?, ?, ?, ?, ?, ?);";
     sqlite3_stmt *stmtIngred = nullptr;
     if (sqlite3_prepare_v2(d_db, insertIngredient.c_str(), -1, &stmtIngred, nullptr) != SQLITE_OK) {
         executeQuery("ROLLBACK;");
@@ -160,6 +180,7 @@ bool DBManager::addMeal(const Meal &meal) {
         sqlite3_bind_double(stmtIngred, 3, ing.getAmount().getValue());
         sqlite3_bind_int(stmtIngred, 4, static_cast<int>(ing.getAmount().getUnit()));
         sqlite3_bind_text(stmtIngred, 5, ing.getPreparation().c_str(), -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int(stmtIngred, 6, ing.isOptional() ? 1 : 0);
 
         if (sqlite3_step(stmtIngred) != SQLITE_DONE) {
             sqlite3_finalize(stmtIngred);
@@ -215,8 +236,8 @@ bool DBManager::updateMeal(const Meal &meal) {
 
     // Insert updated ingredients
     std::string insertIngredient =
-        "INSERT INTO ingredients (meal_id, name, amount, unit, preparation) "
-        "VALUES (?, ?, ?, ?, ?);";
+        "INSERT INTO ingredients (meal_id, name, amount, unit, preparation, is_optional) "
+        "VALUES (?, ?, ?, ?, ?, ?);";
     sqlite3_stmt *stmtIngred = nullptr;
     if (sqlite3_prepare_v2(d_db, insertIngredient.c_str(), -1, &stmtIngred, nullptr) != SQLITE_OK) {
         executeQuery("ROLLBACK;");
@@ -228,6 +249,7 @@ bool DBManager::updateMeal(const Meal &meal) {
         sqlite3_bind_double(stmtIngred, 3, ing.getAmount().getValue());
         sqlite3_bind_int(stmtIngred, 4, static_cast<int>(ing.getAmount().getUnit()));
         sqlite3_bind_text(stmtIngred, 5, ing.getPreparation().c_str(), -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int(stmtIngred, 6, ing.isOptional() ? 1 : 0);
         if (sqlite3_step(stmtIngred) != SQLITE_DONE) {
             sqlite3_finalize(stmtIngred);
             executeQuery("ROLLBACK;");
@@ -279,7 +301,7 @@ std::unique_ptr<Meal> DBManager::getMeal(const std::string &mealName) {
     sqlite3_finalize(stmtCat);
 
     std::string query =
-        "SELECT name, amount, unit, preparation FROM ingredients "
+        "SELECT name, amount, unit, preparation, is_optional FROM ingredients "
         "WHERE meal_id = ?;";
     sqlite3_stmt *stmt = nullptr;
     std::vector<Ingredient> ingredients;
@@ -291,9 +313,11 @@ std::unique_ptr<Meal> DBManager::getMeal(const std::string &mealName) {
             double amount = sqlite3_column_double(stmt, 1);
             int unit = sqlite3_column_int(stmt, 2);
             std::string prep = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 3));
+            bool isOptional = sqlite3_column_int(stmt, 4) != 0;
 
             ingredients.emplace_back(ingName,
-                                     Measurement(amount, static_cast<MeasurementUnit>(unit)), prep);
+                                     Measurement(amount, static_cast<MeasurementUnit>(unit)), prep,
+                                     isOptional);
         }
     }
     sqlite3_finalize(stmt);
@@ -322,6 +346,23 @@ bool DBManager::getAllMeals(std::vector<std::tuple<int, std::string, std::string
     }
     sqlite3_finalize(stmt);
     return true;
+}
+
+std::set<int> DBManager::getMealIdsWithOptionalIngredients() {
+    std::lock_guard<std::recursive_mutex> lock(d_mutex);
+    std::set<int> ids;
+    if (!d_db) return ids;
+
+    const std::string query =
+        "SELECT DISTINCT meal_id FROM ingredients WHERE is_optional = 1;";
+    sqlite3_stmt *stmt = nullptr;
+    if (sqlite3_prepare_v2(d_db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            ids.insert(sqlite3_column_int(stmt, 0));
+        }
+    }
+    sqlite3_finalize(stmt);
+    return ids;
 }
 
 bool DBManager::getAllIngredients(std::vector<std::pair<std::string, std::string>> &ingredients) {

--- a/src/db_manager.h
+++ b/src/db_manager.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -97,6 +98,13 @@ class DBManager {
      * @return true if successful, false otherwise.
      */
     bool getAllMeals(std::vector<std::tuple<int, std::string, std::string>> &meals);
+
+    /**
+     * @brief Returns the set of meal IDs that have at least one optional
+     * ingredient. Used so the UI can show an add-on picker only for meals
+     * that actually have selectable add-ons.
+     */
+    std::set<int> getMealIdsWithOptionalIngredients();
 
     /**
      * @brief Saves Google OAuth2 tokens to the database.

--- a/src/ingredient.h
+++ b/src/ingredient.h
@@ -22,9 +22,15 @@ class Ingredient {
      * @param name The name of the ingredient.
      * @param amount The measurement of the ingredient.
      * @param preparation Optional preparation instructions (default is "None").
+     * @param isOptional Whether this ingredient is an optional add-on that
+     *        users select per-meal-plan (default false).
      */
-    Ingredient(const std::string &name, Measurement amount, const std::string &preparation = "None")
-        : d_name(name), d_measurement(amount), d_preparation(preparation) {}
+    Ingredient(const std::string &name, Measurement amount, const std::string &preparation = "None",
+               bool isOptional = false)
+        : d_name(name),
+          d_measurement(amount),
+          d_preparation(preparation),
+          d_isOptional(isOptional) {}
 
     // Copy constructor
     Ingredient(const Ingredient &other) = default;
@@ -41,6 +47,7 @@ class Ingredient {
     std::string getName() const { return d_name; }
     Measurement getAmount() const { return d_measurement; }
     std::string getPreparation() const { return d_preparation; }
+    bool isOptional() const { return d_isOptional; }
 
     /**
      * @brief Adds the amount of another ingredient of the same type.
@@ -70,6 +77,7 @@ class Ingredient {
     std::string d_name;
     Measurement d_measurement;
     std::string d_preparation;
+    bool d_isOptional{false};
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Ingredient &Ingredient) {

--- a/src/meal_factory.cpp
+++ b/src/meal_factory.cpp
@@ -1,5 +1,6 @@
 #include "meal_factory.h"
 
+#include <set>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -12,12 +13,26 @@
 MealFactory::MealFactory(std::shared_ptr<DBManager> dbManager)
     : d_dbManager(std::move(dbManager)) {}
 
-// Meal factory function
+// Meal factory function — excludes all optional ingredients
 std::unique_ptr<Meal> MealFactory::createMeal(const std::string &mealName) {
-    if (d_dbManager) {
-        return d_dbManager->getMeal(mealName);
+    return createMeal(mealName, {});
+}
+
+std::unique_ptr<Meal> MealFactory::createMeal(const std::string &mealName,
+                                              const std::set<std::string> &enabledAddOns) {
+    if (!d_dbManager) return nullptr;
+    auto raw = d_dbManager->getMeal(mealName);
+    if (!raw) return nullptr;
+
+    std::vector<Ingredient> filtered;
+    filtered.reserve(raw->getIngredients().size());
+    for (const auto &ing : raw->getIngredients()) {
+        if (ing.isOptional() && enabledAddOns.find(ing.getName()) == enabledAddOns.end()) {
+            continue;
+        }
+        filtered.push_back(ing);
     }
-    return nullptr;
+    return std::make_unique<Meal>(raw->getName(), filtered, raw->getCategory());
 }
 
 // Function to get all available meal names and categories

--- a/src/meal_factory.h
+++ b/src/meal_factory.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -24,10 +25,28 @@ class MealFactory {
 
     /**
      * @brief Creates a Meal object by retrieving its details from the database.
+     *
+     * Optional (add-on) ingredients are excluded by default. Use the overload
+     * below to include a specific set of add-ons.
+     *
      * @param mealName The name of the meal to create.
      * @return unique_ptr to the created Meal, or nullptr if not found.
      */
     std::unique_ptr<Meal> createMeal(const std::string &mealName);
+
+    /**
+     * @brief Creates a Meal object including only the selected optional
+     * (add-on) ingredients.
+     *
+     * Base (non-optional) ingredients are always included. An optional
+     * ingredient is included iff its name appears in @p enabledAddOns.
+     *
+     * @param mealName The name of the meal to create.
+     * @param enabledAddOns Names of optional ingredients to include.
+     * @return unique_ptr to the created Meal, or nullptr if not found.
+     */
+    std::unique_ptr<Meal> createMeal(const std::string &mealName,
+                                     const std::set<std::string> &enabledAddOns);
 
     /**
      * @brief Populates a vector with the names and categories of all available

--- a/static/index.html
+++ b/static/index.html
@@ -260,6 +260,24 @@
             </div>
         </div>
 
+        <!-- Add-ons (Optional Ingredients) Picker Modal -->
+        <div id="addons-modal" class="modal hidden">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2 id="addons-title">Add-ons</h2>
+                    <button onclick="closeModal('addons-modal')" class="btn-close" type="button">&times;</button>
+                </div>
+                <p class="text-secondary">Select any add-ons to include with this recipe. Choices reset after you drag it onto the calendar.</p>
+                <div id="addons-list" class="addons-list">
+                    <!-- Populated by JS -->
+                </div>
+                <div class="form-actions mt-4">
+                    <button type="button" onclick="cancelAddonsModal()" class="btn btn-secondary">Cancel</button>
+                    <button type="button" onclick="confirmAddonsModal()" class="btn btn-primary">OK</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Add Ingredient Modal -->
         <div id="add-ingredient-modal" class="modal hidden">
             <div class="modal-content">

--- a/static/script.js
+++ b/static/script.js
@@ -96,9 +96,12 @@ async function fetchMeals() {
     }
 }
 
+let mealMetaById = {}; // { mealId: { hasOptional: bool } }
+
 function renderMeals(meals) {
     const grid = document.getElementById('meal-grid');
     grid.innerHTML = '';
+    mealMetaById = {};
 
     // Format meal names (e.g. "baked-chicken-breast" -> "Baked Chicken Breast")
     const formatName = (str) => {
@@ -111,10 +114,11 @@ function renderMeals(meals) {
     meals.forEach(meal => {
         const cat = meal.category || 'Uncategorized';
         if (!grouped[cat]) grouped[cat] = [];
-        grouped[cat].push(meal.name);
+        grouped[cat].push(meal);
+        mealMetaById[meal.name] = { hasOptional: !!meal.has_optional_ingredients };
     });
 
-    for (const [category, mealNames] of Object.entries(grouped)) {
+    for (const [category, categoryMeals] of Object.entries(grouped)) {
         let index = 0;
         const header = document.createElement('h3');
         header.className = 'category-header collapsed';
@@ -144,7 +148,8 @@ function renderMeals(meals) {
             header.click();
         }, { passive: false });
 
-        mealNames.forEach((mealId) => {
+        categoryMeals.forEach((meal) => {
+            const mealId = meal.name;
             const card = document.createElement('div');
             card.className = 'meal-card';
             card.style.animationDelay = `${index * 0.05}s`;
@@ -158,20 +163,32 @@ function renderMeals(meals) {
             if (mealId.includes('burger') || mealId.includes('hamburger')) emoji = '🍔';
             if (mealId.includes('pancake')) emoji = '🥞';
 
+            const hasOptional = !!meal.has_optional_ingredients;
+            const customizeHint = hasOptional ? '<span class="meal-card-customize">+ add-ons</span>' : '';
+
             card.innerHTML = `
                 <div class="meal-card-header">
                     <h3>${emoji} ${formatName(mealId)}</h3>
+                    ${customizeHint}
                 </div>
+                <div class="meal-card-addons" hidden></div>
             `;
             card.id = `meal-${mealId}-${index}`;
             card.setAttribute('data-meal-id', mealId);
             card.setAttribute('draggable', 'true');
             card.setAttribute('ondragstart', 'drag(event)');
+            if (hasOptional) card.dataset.hasOptional = '1';
 
-            // Add click listener for selection
+            // Click behaviour: if the meal has optional ingredients, the click
+            // opens the add-on picker for this tile. Otherwise, fall back to
+            // the existing selection toggle used by "View Ingredients".
             card.addEventListener('click', (e) => {
-                // Prevent triggering if dragging
                 if (card.classList.contains('dragging')) return;
+
+                if (hasOptional) {
+                    openAddonsModal(card, mealId);
+                    return;
+                }
 
                 if (selectedMeals.has(mealId)) {
                     selectedMeals.delete(mealId);
@@ -186,6 +203,106 @@ function renderMeals(meals) {
             group.appendChild(card);
             attachMealTouchListeners(card, mealId);
         });
+    }
+}
+
+// ── Add-on (optional ingredient) picker ─────────────────────────────────────
+
+let addonsModalState = null; // { cardEl, mealId, initialAddons }
+
+async function openAddonsModal(cardEl, mealId) {
+    // Fetch the full meal so we know which ingredients are optional
+    let meal;
+    try {
+        const res = await fetch(`/api/meals/${encodeURIComponent(mealId)}`);
+        if (!res.ok) throw new Error('fetch failed');
+        meal = await res.json();
+    } catch (e) {
+        console.error('Failed to load meal for add-ons:', e);
+        showToast('Could not load add-ons for this recipe.', false);
+        return;
+    }
+
+    const optionalIngs = (meal.ingredients || []).filter(i => i.optional);
+    if (optionalIngs.length === 0) {
+        // Shouldn't normally happen if has_optional_ingredients was true, but
+        // guard against drift between cached meta and current DB state.
+        return;
+    }
+
+    const currentSelections = new Set(readAddonsFromCard(cardEl));
+    const list = document.getElementById('addons-list');
+    list.innerHTML = '';
+    optionalIngs.forEach(ing => {
+        const label = document.createElement('label');
+        label.className = 'addon-row';
+        const checked = currentSelections.has(ing.name) ? 'checked' : '';
+        label.innerHTML = `
+            <input type="checkbox" class="addon-check" data-name="${ing.name}" ${checked}>
+            <span>${ing.name}</span>
+        `;
+        list.appendChild(label);
+    });
+
+    const title = document.getElementById('addons-title');
+    if (title) {
+        const formatName = mealId.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+        title.textContent = `Add-ons for ${formatName}`;
+    }
+
+    addonsModalState = {
+        cardEl,
+        mealId,
+        initialAddons: Array.from(currentSelections),
+    };
+    document.getElementById('addons-modal').classList.remove('hidden');
+}
+
+function confirmAddonsModal() {
+    if (!addonsModalState) return;
+    const checks = document.querySelectorAll('#addons-list .addon-check');
+    const selected = [];
+    checks.forEach(c => { if (c.checked) selected.push(c.dataset.name); });
+    writeAddonsToCard(addonsModalState.cardEl, selected);
+    closeModal('addons-modal');
+    addonsModalState = null;
+}
+
+function cancelAddonsModal() {
+    closeModal('addons-modal');
+    addonsModalState = null;
+}
+
+function readAddonsFromCard(cardEl) {
+    if (!cardEl || !cardEl.dataset.addons) return [];
+    try {
+        const parsed = JSON.parse(cardEl.dataset.addons);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+        return [];
+    }
+}
+
+function writeAddonsToCard(cardEl, addons) {
+    if (!cardEl) return;
+    if (!addons || addons.length === 0) {
+        delete cardEl.dataset.addons;
+    } else {
+        cardEl.dataset.addons = JSON.stringify(addons);
+    }
+    renderAddonsBadge(cardEl);
+}
+
+function renderAddonsBadge(cardEl) {
+    const badge = cardEl.querySelector('.meal-card-addons');
+    if (!badge) return;
+    const addons = readAddonsFromCard(cardEl);
+    if (addons.length === 0) {
+        badge.hidden = true;
+        badge.textContent = '';
+    } else {
+        badge.hidden = false;
+        badge.textContent = '+ ' + addons.join(', ');
     }
 }
 
@@ -249,6 +366,9 @@ function drop(ev) {
             const dayCol = dropTarget.closest('.day-col');
             if (dayCol) clone.dataset.placedDate = dayCol.dataset.date;
             dropTarget.appendChild(clone);
+            renderAddonsBadge(clone);
+            // Reset the source recipe tile so the next drag starts vanilla
+            writeAddonsToCard(draggedElt, []);
         } else if (!fromGrid && toGrid) {
             // If dragging from a slot back to the grid, just remove it from the planner
             draggedElt.remove();
@@ -337,6 +457,9 @@ function handleDayTap(dayColEl) {
             clone.dataset.placedDate = dayColEl.dataset.date;
             attachMealTouchListeners(clone, mealId);
             mealSlot.appendChild(clone);
+            renderAddonsBadge(clone);
+            // Reset the source recipe tile so the next tap starts vanilla
+            writeAddonsToCard(cardEl, []);
         } else {
             // Moving between slots
             cardEl.dataset.placedDate = dayColEl.dataset.date;
@@ -449,7 +572,13 @@ async function planMeals() {
             if (slot) {
                 const cards = slot.querySelectorAll('.meal-card');
                 cards.forEach(c => {
-                    schedule[day].push(c.getAttribute('data-meal-id'));
+                    const mealId = c.getAttribute('data-meal-id');
+                    const addons = readAddonsFromCard(c);
+                    if (addons.length > 0) {
+                        schedule[day].push({ name: mealId, add_ons: addons });
+                    } else {
+                        schedule[day].push(mealId);
+                    }
                 });
             }
         });
@@ -793,7 +922,7 @@ async function editMeal(mealId) {
             const mealData = await mealRes.json();
             document.getElementById('meal-category').value = mealData.category || "Uncategorized";
             mealData.ingredients.forEach(ing => {
-                addIngredientRow(ing.name, ing.amount, ing.unit);
+                addIngredientRow(ing.name, ing.amount, ing.unit, !!ing.optional);
             });
         } else {
             addIngredientRow(); // Fallback to empty row
@@ -826,7 +955,7 @@ function closeEditView() {
     document.getElementById('manage-edit-view').classList.add('hidden');
 }
 
-function addIngredientRow(name = "", amount = "", unit = 0) {
+function addIngredientRow(name = "", amount = "", unit = 0, optional = false) {
     const container = document.getElementById('ingredients-list');
     const row = document.createElement('div');
     row.className = 'ingredient-row';
@@ -846,6 +975,10 @@ function addIngredientRow(name = "", amount = "", unit = 0) {
         <select class="form-control unit-input">
             ${unitOptions}
         </select>
+        <label class="optional-toggle" title="Optional add-on: users can opt in per meal plan">
+            <input type="checkbox" class="optional-input" ${optional ? 'checked' : ''}>
+            <span>Optional</span>
+        </label>
         <button type="button" class="btn btn-danger btn-sm" onclick="this.parentElement.remove()">X</button>
     `;
 
@@ -889,7 +1022,8 @@ async function saveMeal(e) {
             name: row.querySelector('.name-input').value,
             amount: parseFloat(row.querySelector('.amount-input').value),
             unit: parseInt(row.querySelector('.unit-input').value),
-            preparation: "None"
+            preparation: "None",
+            optional: row.querySelector('.optional-input')?.checked || false
         });
     });
 

--- a/static/style.css
+++ b/static/style.css
@@ -928,10 +928,80 @@ h1 {
 
 .ingredient-row {
     display: grid;
-    grid-template-columns: 2fr 1fr 1fr auto;
+    grid-template-columns: 2fr 1fr 1fr auto auto;
     gap: 6px;
     margin-bottom: 6px;
     align-items: center;
+}
+
+.optional-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+.optional-toggle input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+}
+
+/* Add-on picker modal — checkboxes for each optional ingredient */
+.addons-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 12px;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.addon-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.1s;
+}
+
+.addon-row:hover {
+    background: var(--bg-alt, rgba(0, 0, 0, 0.03));
+}
+
+.addon-row input[type="checkbox"] {
+    cursor: pointer;
+}
+
+/* Recipe-tile hint that this meal has selectable add-ons */
+.meal-card-customize {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 1px 6px;
+    border-radius: 10px;
+    background: var(--accent-soft, rgba(99, 102, 241, 0.12));
+    color: var(--accent-color, #6366f1);
+    font-size: 10px;
+    font-weight: 600;
+    vertical-align: middle;
+}
+
+/* Badge on a recipe tile or scheduled slot when add-ons are chosen */
+.meal-card-addons {
+    margin-top: 4px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--accent-soft, rgba(99, 102, 241, 0.12));
+    color: var(--accent-color, #6366f1);
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1.2;
 }
 
 .form-actions {
@@ -1231,9 +1301,9 @@ h1 {
         min-height: 200px;
     }
 
-    /* Ingredient rows on mobile: name on row 1, amount/unit/del on row 2 */
+    /* Ingredient rows on mobile: name on row 1, amount/unit/optional/del on row 2 */
     .ingredient-row {
-        grid-template-columns: 1fr 1fr auto;
+        grid-template-columns: 1fr 1fr auto auto;
         grid-template-rows: auto auto;
     }
 

--- a/tests/test_db_manager.cpp
+++ b/tests/test_db_manager.cpp
@@ -242,3 +242,69 @@ TEST_F(DBManagerTest, AddDuplicateMealFails) {
     EXPECT_TRUE(db->addMeal(makeMeal("unique-meal")));
     EXPECT_FALSE(db->addMeal(makeMeal("unique-meal")));
 }
+
+// is_optional flag round-trips through add/get for a meal's ingredients
+TEST_F(DBManagerTest, OptionalIngredientFlagRoundTrips) {
+    std::vector<Ingredient> ings = {
+        Ingredient("All-Purpose Flour", Measurement(1.0, MeasurementUnit::CUP), "None", false),
+        Ingredient("Blueberry", Measurement(0.5, MeasurementUnit::CUP), "None", true),
+        Ingredient("Cottage Cheese", Measurement(1.0, MeasurementUnit::CUP), "None", true),
+    };
+    Meal meal("pancakes", ings, "Breakfast");
+    EXPECT_TRUE(db->addMeal(meal));
+
+    auto retrieved = db->getMeal("pancakes");
+    ASSERT_NE(retrieved, nullptr);
+    ASSERT_EQ(retrieved->getIngredients().size(), 3u);
+    for (const auto &ing : retrieved->getIngredients()) {
+        if (ing.getName() == "All-Purpose Flour") {
+            EXPECT_FALSE(ing.isOptional());
+        } else {
+            EXPECT_TRUE(ing.isOptional());
+        }
+    }
+}
+
+// updateMeal preserves the is_optional flag on replacement
+TEST_F(DBManagerTest, UpdateMealPreservesOptionalFlag) {
+    db->addMeal(makeMeal("update-pancakes"));
+    std::vector<Ingredient> ings = {
+        Ingredient("Eggs", Measurement(2.0, MeasurementUnit::WHOLE), "None", false),
+        Ingredient("Pumpkin", Measurement(0.25, MeasurementUnit::CUP), "None", true),
+    };
+    Meal updated("update-pancakes", ings, "Breakfast");
+    EXPECT_TRUE(db->updateMeal(updated));
+
+    auto retrieved = db->getMeal("update-pancakes");
+    ASSERT_NE(retrieved, nullptr);
+    ASSERT_EQ(retrieved->getIngredients().size(), 2u);
+    for (const auto &ing : retrieved->getIngredients()) {
+        if (ing.getName() == "Pumpkin") EXPECT_TRUE(ing.isOptional());
+        if (ing.getName() == "Eggs") EXPECT_FALSE(ing.isOptional());
+    }
+}
+
+// getMealIdsWithOptionalIngredients identifies meals with any optional ingredient
+TEST_F(DBManagerTest, GetMealIdsWithOptionalIngredients) {
+    db->addMeal(Meal(
+        "no-options", {Ingredient("Salt", Measurement(1.0, MeasurementUnit::TEASPOON))}, "Cat"));
+    db->addMeal(Meal("with-options",
+                     {Ingredient("Eggs", Measurement(2.0, MeasurementUnit::WHOLE)),
+                      Ingredient("Blueberry", Measurement(0.5, MeasurementUnit::CUP), "None", true)},
+                     "Cat"));
+
+    auto ids = db->getMealIdsWithOptionalIngredients();
+
+    std::vector<std::tuple<int, std::string, std::string>> meals;
+    db->getAllMeals(meals);
+    int noOptionsId = -1, withOptionsId = -1;
+    for (const auto &m : meals) {
+        if (std::get<1>(m) == "no-options") noOptionsId = std::get<0>(m);
+        if (std::get<1>(m) == "with-options") withOptionsId = std::get<0>(m);
+    }
+    ASSERT_NE(noOptionsId, -1);
+    ASSERT_NE(withOptionsId, -1);
+
+    EXPECT_EQ(ids.count(noOptionsId), 0u);
+    EXPECT_EQ(ids.count(withOptionsId), 1u);
+}

--- a/tests/test_ingredient.cpp
+++ b/tests/test_ingredient.cpp
@@ -127,3 +127,15 @@ TEST_F(IngredientTest, AssignmentOperator) {
     EXPECT_EQ(ing2.getName(), "Spinach");
     EXPECT_DOUBLE_EQ(ing2.getAmount().getValue(), 3.0);
 }
+
+// Test isOptional defaults to false
+TEST_F(IngredientTest, IsOptionalDefaultsFalse) {
+    Ingredient ing("Spinach", Measurement(1.0, MeasurementUnit::CUP));
+    EXPECT_FALSE(ing.isOptional());
+}
+
+// Test isOptional can be set via constructor
+TEST_F(IngredientTest, IsOptionalCanBeSet) {
+    Ingredient ing("Blueberry", Measurement(0.5, MeasurementUnit::CUP), "None", true);
+    EXPECT_TRUE(ing.isOptional());
+}

--- a/tests/test_meal_factory.cpp
+++ b/tests/test_meal_factory.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <set>
+#include <string>
 #include <tuple>
 
 #include "../src/db_manager.h"
@@ -69,6 +71,49 @@ TEST_F(MealFactoryTest, GetAvailableMeals) {
 
     EXPECT_TRUE(hasTurkeyBurgers);
     EXPECT_TRUE(hasChickenStirFry);
+}
+
+// createMeal without an add-on set excludes all optional ingredients
+TEST_F(MealFactoryTest, CreateMealExcludesOptionalByDefault) {
+    auto dbManager = std::make_shared<DBManager>(":memory:");
+    dbManager->initializeSchema();
+    std::vector<Ingredient> ings = {
+        Ingredient("Eggs", Measurement(2.0, MeasurementUnit::WHOLE), "None", false),
+        Ingredient("Cottage Cheese", Measurement(1.0, MeasurementUnit::CUP), "None", true),
+        Ingredient("Pumpkin", Measurement(0.25, MeasurementUnit::CUP), "None", true),
+    };
+    dbManager->addMeal(Meal("pancakes-test", ings, "Breakfast"));
+    MealFactory localFactory(dbManager);
+
+    auto meal = localFactory.createMeal("pancakes-test");
+    ASSERT_NE(meal, nullptr);
+    EXPECT_EQ(meal->getIngredients().size(), 1u);
+    EXPECT_EQ(meal->getIngredients()[0].getName(), "Eggs");
+}
+
+// createMeal with a set of enabled add-ons includes only the matching optionals
+TEST_F(MealFactoryTest, CreateMealIncludesSelectedAddOns) {
+    auto dbManager = std::make_shared<DBManager>(":memory:");
+    dbManager->initializeSchema();
+    std::vector<Ingredient> ings = {
+        Ingredient("Eggs", Measurement(2.0, MeasurementUnit::WHOLE), "None", false),
+        Ingredient("Cottage Cheese", Measurement(1.0, MeasurementUnit::CUP), "None", true),
+        Ingredient("Pumpkin", Measurement(0.25, MeasurementUnit::CUP), "None", true),
+        Ingredient("Blueberry", Measurement(0.5, MeasurementUnit::CUP), "None", true),
+    };
+    dbManager->addMeal(Meal("pancakes-test", ings, "Breakfast"));
+    MealFactory localFactory(dbManager);
+
+    auto meal = localFactory.createMeal("pancakes-test", {"Blueberry", "Pumpkin"});
+    ASSERT_NE(meal, nullptr);
+    EXPECT_EQ(meal->getIngredients().size(), 3u);
+
+    std::set<std::string> names;
+    for (const auto &i : meal->getIngredients()) names.insert(i.getName());
+    EXPECT_EQ(names.count("Eggs"), 1u);
+    EXPECT_EQ(names.count("Blueberry"), 1u);
+    EXPECT_EQ(names.count("Pumpkin"), 1u);
+    EXPECT_EQ(names.count("Cottage Cheese"), 0u);
 }
 
 // Test that all available meals can be creatable


### PR DESCRIPTION
Lets one recipe (e.g. "Pancakes") carry per-instance add-ons (e.g.
Cottage Cheese, Blueberries) instead of duplicating the recipe per
variant. Picking add-ons happens at scheduling time: clicking a recipe
tile opens a checkbox modal; the chosen add-ons ride along when the
tile is dragged onto a day and are included in the grocery list.

- ingredients.is_optional column (with ALTER TABLE migration)
- Ingredient.isOptional() round-trips through add/update/get
- MealFactory.createMeal(name, addOns) filters optional ingredients;
  the single-arg overload returns the base recipe only
- /api/meals exposes has_optional_ingredients per meal
- /api/plan accepts either a bare meal name or {name, add_ons:[...]}
- Editor adds an "Optional" checkbox per ingredient row
- Add-on picker modal + tile badge + reset-on-drop in the planner UI