### PR TITLE
Show Manage Recipes button on mobile

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -104,6 +104,9 @@
             <aside class="recipe-library sidebar-container" data-panel="meals">
                 <div class="recipe-library-h">
                     <h2>Recipes</h2>
+                    <button type="button" class="btn btn-sm mobile-manage-btn" onclick="openManageModal()">
+                        Manage Recipes
+                    </button>
                 </div>
                 <p class="touch-hint">Tap a recipe, then tap a day to assign it.</p>
                 <div class="meal-grid" id="meal-grid" ondrop="drop(event)" ondragover="allowDrop(event)">

--- a/static/style.css
+++ b/static/style.css
@@ -357,6 +357,10 @@ h1 {
 
 .recipe-library-h {
     margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
 }
 
 .recipe-library-h h2 {
@@ -365,6 +369,10 @@ h1 {
     letter-spacing: 0.12em;
     color: var(--ink-3);
     font-weight: 600;
+}
+
+.mobile-manage-btn {
+    display: none;
 }
 
 .kanban-week {
@@ -1221,6 +1229,10 @@ h1 {
         border-right: 0;
         max-height: none;
         padding: 16px;
+    }
+
+    .mobile-manage-btn {
+        display: inline-flex;
     }
 
     /* Mobile tab bar */


### PR DESCRIPTION
## Summary
- The Manage Recipes entry lives only in the sidebar nav, which the mobile breakpoint (`@media (max-width: 768px)`) hides via `display: none` on `.sidebar-nav`. That left mobile users with no way to open the manage modal.
- Adds a mobile-only `Manage Recipes` button inside the Recipes panel header. It is hidden by default and revealed inside the existing mobile media query, so the desktop layout is unchanged.
- `.recipe-library-h` is converted to a flex row so the heading and the new button sit on the same line.

## Test plan
- [ ] Open the app at desktop width — sidebar still shows Manage Recipes; no duplicate button appears in the Recipes panel.
- [ ] Narrow the viewport below 768px (or use device mode) — the sidebar nav is hidden and the new Manage Recipes button appears in the Recipes header.
- [ ] Tap the new button on mobile and confirm `openManageModal()` opens the existing Manage Recipes modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)