### PR TITLE
Add cancel X on planner meal cards and consolidate header actions

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -28,11 +28,6 @@
                 <span class="nav-ico">▤</span>
                 <span>Weekly Planner</span>
             </div>
-            <button type="button" class="nav-item nav-item-btn" onclick="openManageModal()">
-                <span class="nav-chev"></span>
-                <span class="nav-ico">▦</span>
-                <span>Manage Recipes</span>
-            </button>
         </nav>
 
         <div class="nav-section">Integrations</div>
@@ -58,23 +53,23 @@
                 <span class="sep">/</span>
                 <span id="week-label">This week</span>
             </div>
-            <div class="topbar-r">
+        </header>
+
+        <section class="page-h">
+            <div>
                 <div class="topbar-actions hidden" id="action-bar">
                     <span class="selection-count" id="selection-chip" hidden><b id="selected-count">0</b> selected</span>
                     <button id="view-ingredients-btn" type="button" class="btn btn-secondary" onclick="viewIngredients()" disabled>
                         View Ingredients
+                    </button>
+                    <button id="manage-recipes-btn" type="button" class="btn btn-secondary" onclick="openManageModal()">
+                        Manage Recipes
                     </button>
                     <button id="plan-btn" type="button" class="btn btn-primary" onclick="planMeals()" disabled>
                         <span class="btn-text">Generate Plan</span>
                         <div class="btn-loader hidden"></div>
                     </button>
                 </div>
-            </div>
-        </header>
-
-        <section class="page-h">
-            <div>
-                <div class="page-icon">▤</div>
                 <h1>Weekly Meal Prep</h1>
                 <p class="page-desc">Drag a recipe onto any day, then generate a plan and grocery list for the week.</p>
             </div>
@@ -104,9 +99,6 @@
             <aside class="recipe-library sidebar-container" data-panel="meals">
                 <div class="recipe-library-h">
                     <h2>Recipes</h2>
-                    <button type="button" class="btn btn-sm mobile-manage-btn" onclick="openManageModal()">
-                        Manage Recipes
-                    </button>
                 </div>
                 <p class="touch-hint">Tap a recipe, then tap a day to assign it.</p>
                 <div class="meal-grid" id="meal-grid" ondrop="drop(event)" ondragover="allowDrop(event)">

--- a/static/script.js
+++ b/static/script.js
@@ -172,6 +172,7 @@ function renderMeals(meals) {
                     ${customizeHint}
                 </div>
                 <div class="meal-card-addons" hidden></div>
+                <button type="button" class="meal-card-remove" draggable="false" onclick="removeMealFromSlot(event, this)" title="Remove from day" aria-label="Remove from day">&times;</button>
             `;
             card.id = `meal-${mealId}-${index}`;
             card.setAttribute('data-meal-id', mealId);
@@ -384,6 +385,15 @@ function drop(ev) {
             draggedElt.classList.remove('selected');
         }
 
+        updateActionBar();
+    }
+}
+
+function removeMealFromSlot(ev, btn) {
+    ev.stopPropagation();
+    const card = btn.closest('.meal-card');
+    if (card && card.closest('.meal-slot')) {
+        card.remove();
         updateActionBar();
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -245,13 +245,6 @@ body {
     color: var(--ink-3);
 }
 
-.topbar-r {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    min-height: 32px;
-}
-
 .topbar-actions {
     display: flex;
     align-items: center;
@@ -287,10 +280,8 @@ body {
     background: var(--paper);
 }
 
-.page-icon {
-    font-size: 22px;
-    margin-bottom: 6px;
-    color: var(--ink-2);
+.page-h .topbar-actions {
+    margin-bottom: 8px;
 }
 
 h1 {
@@ -369,10 +360,6 @@ h1 {
     letter-spacing: 0.12em;
     color: var(--ink-3);
     font-weight: 600;
-}
-
-.mobile-manage-btn {
-    display: none;
 }
 
 .kanban-week {
@@ -486,12 +473,37 @@ h1 {
 
 /* Meal card — kanban variant (when dropped into a day slot) */
 .meal-slot .meal-card {
+    position: relative;
     background: var(--paper);
     border: 1px solid var(--line-2);
     border-left: 3px solid var(--accent-color);
     border-radius: 6px;
-    padding: 8px 10px;
+    padding: 8px 22px 8px 10px;
     box-shadow: 0 1px 2px rgba(17, 17, 17, 0.04);
+}
+
+.meal-card-remove {
+    display: none;
+}
+
+.meal-slot .meal-card .meal-card-remove {
+    display: block;
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    background: none;
+    border: none;
+    color: var(--ink-3);
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+    border-radius: 3px;
+}
+
+.meal-slot .meal-card .meal-card-remove:hover {
+    color: var(--error-color);
+    background: rgba(220, 38, 38, 0.08);
 }
 
 .meal-slot .meal-card h3 {
@@ -1229,10 +1241,6 @@ h1 {
         border-right: 0;
         max-height: none;
         padding: 16px;
-    }
-
-    .mobile-manage-btn {
-        display: inline-flex;
     }
 
     /* Mobile tab bar */


### PR DESCRIPTION
## Summary
- Adds an X button in the top-right of meal cards once they are dropped into a calendar day slot, so a planned meal can be removed without dragging it back to the recipe grid.
- Moves the selection count, **View Ingredients**, and **Generate Plan** buttons from the breadcrumb bar to sit above the *Weekly Meal Prep* heading. The decorative `▤` page icon is removed.
- Moves **Manage Recipes** out of the left sidebar (and out of the mobile-only recipe library header) into the same action bar next to *View Ingredients*, putting all planner actions in one place.

## Test plan
- [ ] `make build && make start`, open the app
- [ ] Drag a recipe onto a day — confirm the card shows an X in the top-right
- [ ] Click the X — confirm only that one card is removed from the slot and the selection count decrements; the source recipe stays in the grid
- [ ] Confirm clicking the X does not start a drag or toggle the card's selected state
- [ ] Confirm the X is *not* visible on recipe cards in the left grid (only on cards inside day slots)
- [ ] Confirm the action bar (count + View Ingredients + Manage Recipes + Generate Plan) renders above "Weekly Meal Prep" instead of in the top bar
- [ ] Confirm the decorative ▤ icon is gone
- [ ] Click **Manage Recipes** from the action bar — confirm the manage modal opens
- [ ] Confirm the old sidebar "Manage Recipes" entry is gone, and the mobile-only duplicate inside the Recipes panel is gone
- [ ] Resize to mobile width — confirm the action bar still works and Manage Recipes is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)