### PR TITLE
Fold selection count into View Ingredients label and reorder actions

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -58,12 +58,11 @@
         <section class="page-h">
             <div>
                 <div class="topbar-actions hidden" id="action-bar">
-                    <span class="selection-count" id="selection-chip" hidden><b id="selected-count">0</b> selected</span>
-                    <button id="view-ingredients-btn" type="button" class="btn btn-secondary" onclick="viewIngredients()" disabled>
-                        View Ingredients
-                    </button>
                     <button id="manage-recipes-btn" type="button" class="btn btn-secondary" onclick="openManageModal()">
                         Manage Recipes
+                    </button>
+                    <button id="view-ingredients-btn" type="button" class="btn btn-secondary" onclick="viewIngredients()" disabled>
+                        <span class="btn-text">View Ingredients</span>
                     </button>
                     <button id="plan-btn" type="button" class="btn btn-primary" onclick="planMeals()" disabled>
                         <span class="btn-text">Generate Plan</span>

--- a/static/index.html
+++ b/static/index.html
@@ -28,11 +28,6 @@
                 <span class="nav-ico">▤</span>
                 <span>Weekly Planner</span>
             </div>
-            <button type="button" class="nav-item nav-item-btn" onclick="openManageModal()">
-                <span class="nav-chev"></span>
-                <span class="nav-ico">▦</span>
-                <span>Manage Recipes</span>
-            </button>
         </nav>
 
         <div class="nav-section">Integrations</div>
@@ -58,23 +53,23 @@
                 <span class="sep">/</span>
                 <span id="week-label">This week</span>
             </div>
-            <div class="topbar-r">
+        </header>
+
+        <section class="page-h">
+            <div>
                 <div class="topbar-actions hidden" id="action-bar">
                     <span class="selection-count" id="selection-chip" hidden><b id="selected-count">0</b> selected</span>
                     <button id="view-ingredients-btn" type="button" class="btn btn-secondary" onclick="viewIngredients()" disabled>
                         View Ingredients
+                    </button>
+                    <button id="manage-recipes-btn" type="button" class="btn btn-secondary" onclick="openManageModal()">
+                        Manage Recipes
                     </button>
                     <button id="plan-btn" type="button" class="btn btn-primary" onclick="planMeals()" disabled>
                         <span class="btn-text">Generate Plan</span>
                         <div class="btn-loader hidden"></div>
                     </button>
                 </div>
-            </div>
-        </header>
-
-        <section class="page-h">
-            <div>
-                <div class="page-icon">▤</div>
                 <h1>Weekly Meal Prep</h1>
                 <p class="page-desc">Drag a recipe onto any day, then generate a plan and grocery list for the week.</p>
             </div>
@@ -104,9 +99,6 @@
             <aside class="recipe-library sidebar-container" data-panel="meals">
                 <div class="recipe-library-h">
                     <h2>Recipes</h2>
-                    <button type="button" class="btn btn-sm mobile-manage-btn" onclick="openManageModal()">
-                        Manage Recipes
-                    </button>
                 </div>
                 <p class="touch-hint">Tap a recipe, then tap a day to assign it.</p>
                 <div class="meal-grid" id="meal-grid" ondrop="drop(event)" ondragover="allowDrop(event)">

--- a/static/script.js
+++ b/static/script.js
@@ -172,6 +172,7 @@ function renderMeals(meals) {
                     ${customizeHint}
                 </div>
                 <div class="meal-card-addons" hidden></div>
+                <button type="button" class="meal-card-remove" draggable="false" onclick="removeMealFromSlot(event, this)" title="Remove from day" aria-label="Remove from day">&times;</button>
             `;
             card.id = `meal-${mealId}-${index}`;
             card.setAttribute('data-meal-id', mealId);
@@ -384,6 +385,15 @@ function drop(ev) {
             draggedElt.classList.remove('selected');
         }
 
+        updateActionBar();
+    }
+}
+
+function removeMealFromSlot(ev, btn) {
+    ev.stopPropagation();
+    const card = btn.closest('.meal-card');
+    if (card && card.closest('.meal-slot')) {
+        card.remove();
         updateActionBar();
     }
 }

--- a/static/script.js
+++ b/static/script.js
@@ -549,10 +549,9 @@ function attachDayTouchListeners(dayColEl) {
 }
 
 function updateActionBar() {
-    const countSpan = document.getElementById('selected-count');
-    const chip = document.getElementById('selection-chip');
     const planBtn = document.getElementById('plan-btn');
     const viewBtn = document.getElementById('view-ingredients-btn');
+    const viewBtnText = viewBtn.querySelector('.btn-text');
 
     let count = 0;
     const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
@@ -564,8 +563,7 @@ function updateActionBar() {
     });
 
     const totalSelected = count + selectedMeals.size;
-    countSpan.textContent = totalSelected;
-    if (chip) chip.hidden = totalSelected === 0;
+    viewBtnText.textContent = totalSelected > 1 ? `View Ingredients (${totalSelected})` : 'View Ingredients';
 
     if (totalSelected > 0) {
         planBtn.removeAttribute('disabled');
@@ -580,7 +578,7 @@ function updateActionBar() {
 }
 
 async function planMeals() {
-    if (document.getElementById('selected-count').textContent === "0" || isPlanning) return;
+    if (document.getElementById('plan-btn').hasAttribute('disabled') || isPlanning) return;
 
     isPlanning = true;
     const btn = document.getElementById('plan-btn');

--- a/static/style.css
+++ b/static/style.css
@@ -251,24 +251,6 @@ body {
     gap: 10px;
 }
 
-.topbar-actions .selection-count {
-    font-size: 12px;
-    color: var(--ink-2);
-    background: var(--bg-2);
-    border-radius: 999px;
-    padding: 4px 10px;
-    line-height: 1.2;
-}
-
-.topbar-actions .selection-count[hidden] {
-    display: none;
-}
-
-.topbar-actions .selection-count b {
-    color: var(--ink);
-    font-weight: 600;
-}
-
 /* Page header */
 .page-h {
     padding: 22px 28px 18px;

--- a/static/style.css
+++ b/static/style.css
@@ -245,13 +245,6 @@ body {
     color: var(--ink-3);
 }
 
-.topbar-r {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    min-height: 32px;
-}
-
 .topbar-actions {
     display: flex;
     align-items: center;
@@ -287,10 +280,8 @@ body {
     background: var(--paper);
 }
 
-.page-icon {
-    font-size: 22px;
-    margin-bottom: 6px;
-    color: var(--ink-2);
+.page-h .topbar-actions {
+    margin-bottom: 8px;
 }
 
 h1 {
@@ -369,10 +360,6 @@ h1 {
     letter-spacing: 0.12em;
     color: var(--ink-3);
     font-weight: 600;
-}
-
-.mobile-manage-btn {
-    display: none;
 }
 
 .kanban-week {
@@ -486,12 +473,37 @@ h1 {
 
 /* Meal card — kanban variant (when dropped into a day slot) */
 .meal-slot .meal-card {
+    position: relative;
     background: var(--paper);
     border: 1px solid var(--line-2);
     border-left: 3px solid var(--accent-color);
     border-radius: 6px;
-    padding: 8px 10px;
+    padding: 8px 22px 8px 10px;
     box-shadow: 0 1px 2px rgba(17, 17, 17, 0.04);
+}
+
+.meal-card-remove {
+    display: none;
+}
+
+.meal-slot .meal-card .meal-card-remove {
+    display: block;
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    background: none;
+    border: none;
+    color: var(--ink-3);
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+    border-radius: 3px;
+}
+
+.meal-slot .meal-card .meal-card-remove:hover {
+    color: var(--error-color);
+    background: rgba(220, 38, 38, 0.08);
 }
 
 .meal-slot .meal-card h3 {
@@ -1229,10 +1241,6 @@ h1 {
         border-right: 0;
         max-height: none;
         padding: 16px;
-    }
-
-    .mobile-manage-btn {
-        display: inline-flex;
     }
 
     /* Mobile tab bar */


### PR DESCRIPTION
## Summary
- Removes the standalone "X selected" chip from the action bar.
- The **View Ingredients** button label becomes `View Ingredients (N)` when more than one item is selected (grid recipes + meal cards already in day slots), keeping the same total the chip used to show.
- Reorders the action bar so **Manage Recipes** sits to the left of **View Ingredients**, with **Generate Plan** still on the right.

Follow-up to #56.

## Test plan
- [ ] `make build && make start`, open the app
- [ ] With no selections: the action bar shows just the three buttons; the View Ingredients label is `View Ingredients` (no count, button disabled)
- [ ] Select one recipe from the grid: View Ingredients enables, label stays `View Ingredients`
- [ ] Select a second recipe: label becomes `View Ingredients (2)`
- [ ] Drag a recipe into a day slot (without selecting it in the grid): label increments to include slot cards in the count (chip parity)
- [ ] Confirm Generate Plan still enables based on the same total
- [ ] Confirm button order in the bar is: Manage Recipes, View Ingredients, Generate Plan
- [ ] Confirm clicking Generate Plan still works (no `#selected-count` JS error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)