### PR TITLE
Remove duplicate Manage Recipes button in action bar

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -64,9 +64,6 @@
                     <button id="view-ingredients-btn" type="button" class="btn btn-secondary" onclick="viewIngredients()" disabled>
                         <span class="btn-text">View Ingredients</span>
                     </button>
-                    <button id="manage-recipes-btn" type="button" class="btn btn-secondary" onclick="openManageModal()">
-                        Manage Recipes
-                    </button>
                     <button id="plan-btn" type="button" class="btn btn-primary" onclick="planMeals()" disabled>
                         <span class="btn-text">Generate Plan</span>
                         <div class="btn-loader hidden"></div>


### PR DESCRIPTION
## Summary
PRs #56 and #57 both added a **Manage Recipes** button to the action bar, so two copies landed on `main`: one left of *View Ingredients*, and another between *View Ingredients* and *Generate Plan*. This drops the duplicate and keeps the leftmost button.

After this change the action bar order is: **Manage Recipes | View Ingredients | Generate Plan** — the intended layout from #57.

## Test plan
- [ ] `make build && make start`, open the app
- [ ] Confirm only one Manage Recipes button is visible in the action bar (no duplicate after View Ingredients)
- [ ] Confirm the order is: Manage Recipes, View Ingredients, Generate Plan
- [ ] Click Manage Recipes — confirm the modal still opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)