### PR TITLE
Add verified flag to meals with toggle and badge

### DIFF
--- a/src/api_routes.cpp
+++ b/src/api_routes.cpp
@@ -16,7 +16,7 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
     // Route: Get all available meals
     CROW_ROUTE(app, "/api/meals")
     ([&factory, &dbManager]() {
-        std::vector<std::tuple<int, std::string, std::string>> meals;
+        std::vector<std::tuple<int, std::string, std::string, bool>> meals;
         factory.getAvailableMeals(meals);
         std::set<int> idsWithOptional = dbManager->getMealIdsWithOptionalIngredients();
         crow::json::wvalue res;
@@ -25,6 +25,7 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
             res[i]["id"] = id;
             res[i]["name"] = std::get<1>(meals[i]);
             res[i]["category"] = std::get<2>(meals[i]);
+            res[i]["verified"] = std::get<3>(meals[i]);
             res[i]["has_optional_ingredients"] = idsWithOptional.count(id) > 0;
         }
         CROW_LOG_INFO << "Successfully retrieved " << meals.size() << " available meals";
@@ -109,7 +110,12 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
                     category = body["category"].s();
                 }
 
-                Meal newMeal(mealName, ingredients, category);
+                bool verified = false;
+                if (body.has("verified")) {
+                    verified = body["verified"].b();
+                }
+
+                Meal newMeal(mealName, ingredients, category, verified);
                 if (dbManager->addMeal(newMeal)) {
                     CROW_LOG_INFO << "Successfully added meal: " << mealName;
                     return crow::response(200, "Meal added successfully");
@@ -165,8 +171,13 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
                         category = body["category"].s();
                     }
 
+                    bool verified = false;
+                    if (body.has("verified")) {
+                        verified = body["verified"].b();
+                    }
+
                     // Name from URL is used
-                    Meal updatedMeal(mealName, ingredients, category);
+                    Meal updatedMeal(mealName, ingredients, category, verified);
                     if (dbManager->updateMeal(updatedMeal)) {
                         CROW_LOG_INFO << "Successfully updated meal: " << mealName;
                         return crow::response(200, "Meal updated successfully");
@@ -202,6 +213,7 @@ void setupRoutes(crow::App<RequestTimerMiddleware> &app, std::shared_ptr<DBManag
                 crow::json::wvalue res;
                 res["name"] = meal->getName();
                 res["category"] = meal->getCategory();
+                res["verified"] = meal->isVerified();
                 for (size_t i = 0; i < meal->getIngredients().size(); ++i) {
                     const auto &ing = meal->getIngredients()[i];
                     res["ingredients"][i]["name"] = ing.getName();

--- a/src/db_manager.cpp
+++ b/src/db_manager.cpp
@@ -40,7 +40,8 @@ bool DBManager::initializeSchema() {
         "CREATE TABLE IF NOT EXISTS meals ("
         "id INTEGER PRIMARY KEY AUTOINCREMENT, "
         "name TEXT UNIQUE NOT NULL, "
-        "category TEXT DEFAULT 'Uncategorized'"
+        "category TEXT DEFAULT 'Uncategorized', "
+        "verified INTEGER NOT NULL DEFAULT 0"
         ");";
 
     std::string createIngredientsTable =
@@ -167,6 +168,25 @@ bool DBManager::initializeSchema() {
         executeQuery("ALTER TABLE meals ADD COLUMN category TEXT DEFAULT 'Uncategorized';");
     }
 
+    // Add verified column to existing databases if it doesn't exist
+    bool verifiedColumnExists = false;
+    sqlite3_stmt *stmtVerified = nullptr;
+    if (sqlite3_prepare_v2(d_db, checkColumn.c_str(), -1, &stmtVerified, nullptr) == SQLITE_OK) {
+        while (sqlite3_step(stmtVerified) == SQLITE_ROW) {
+            const char *colName =
+                reinterpret_cast<const char *>(sqlite3_column_text(stmtVerified, 1));
+            if (colName && std::string(colName) == "verified") {
+                verifiedColumnExists = true;
+                break;
+            }
+        }
+        sqlite3_finalize(stmtVerified);
+    }
+
+    if (!verifiedColumnExists) {
+        executeQuery("ALTER TABLE meals ADD COLUMN verified INTEGER NOT NULL DEFAULT 0;");
+    }
+
     if (!executeQuery(createIngredientsTable)) return false;
 
     // Add is_optional column to existing ingredients tables if it doesn't exist
@@ -228,7 +248,7 @@ bool DBManager::addMeal(const Meal &meal) {
     // Begin transaction
     executeQuery("BEGIN TRANSACTION;");
 
-    std::string insertMeal = "INSERT INTO meals (name, category) VALUES (?, ?);";
+    std::string insertMeal = "INSERT INTO meals (name, category, verified) VALUES (?, ?, ?);";
     sqlite3_stmt *stmtMeal = nullptr;
     if (sqlite3_prepare_v2(d_db, insertMeal.c_str(), -1, &stmtMeal, nullptr) != SQLITE_OK) {
         executeQuery("ROLLBACK;");
@@ -237,6 +257,7 @@ bool DBManager::addMeal(const Meal &meal) {
 
     sqlite3_bind_text(stmtMeal, 1, meal.getName().c_str(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmtMeal, 2, meal.getCategory().c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmtMeal, 3, meal.isVerified() ? 1 : 0);
     if (sqlite3_step(stmtMeal) != SQLITE_DONE) {
         sqlite3_finalize(stmtMeal);
         executeQuery("ROLLBACK;");
@@ -298,7 +319,7 @@ bool DBManager::updateMeal(const Meal &meal) {
     }
 
     // Insert updated meal row
-    std::string insertMeal = "INSERT INTO meals (name, category) VALUES (?, ?);";
+    std::string insertMeal = "INSERT INTO meals (name, category, verified) VALUES (?, ?, ?);";
     sqlite3_stmt *stmtMeal = nullptr;
     if (sqlite3_prepare_v2(d_db, insertMeal.c_str(), -1, &stmtMeal, nullptr) != SQLITE_OK) {
         executeQuery("ROLLBACK;");
@@ -306,6 +327,7 @@ bool DBManager::updateMeal(const Meal &meal) {
     }
     sqlite3_bind_text(stmtMeal, 1, meal.getName().c_str(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmtMeal, 2, meal.getCategory().c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmtMeal, 3, meal.isVerified() ? 1 : 0);
     if (sqlite3_step(stmtMeal) != SQLITE_DONE) {
         sqlite3_finalize(stmtMeal);
         executeQuery("ROLLBACK;");
@@ -367,9 +389,10 @@ std::unique_ptr<Meal> DBManager::getMeal(const std::string &mealName) {
     int mealId = getMealId(mealName);
     if (mealId == -1) return nullptr;
 
-    std::string getCategoryQuery = "SELECT category FROM meals WHERE id = ?;";
+    std::string getCategoryQuery = "SELECT category, verified FROM meals WHERE id = ?;";
     sqlite3_stmt *stmtCat = nullptr;
     std::string category = "Uncategorized";
+    bool verified = false;
     if (sqlite3_prepare_v2(d_db, getCategoryQuery.c_str(), -1, &stmtCat, nullptr) == SQLITE_OK) {
         sqlite3_bind_int(stmtCat, 1, mealId);
         if (sqlite3_step(stmtCat) == SQLITE_ROW) {
@@ -377,6 +400,7 @@ std::unique_ptr<Meal> DBManager::getMeal(const std::string &mealName) {
                     reinterpret_cast<const char *>(sqlite3_column_text(stmtCat, 0))) {
                 category = catText;
             }
+            verified = sqlite3_column_int(stmtCat, 1) != 0;
         }
     }
     sqlite3_finalize(stmtCat);
@@ -403,14 +427,14 @@ std::unique_ptr<Meal> DBManager::getMeal(const std::string &mealName) {
     }
     sqlite3_finalize(stmt);
 
-    return std::make_unique<Meal>(mealName, ingredients, category);
+    return std::make_unique<Meal>(mealName, ingredients, category, verified);
 }
 
-bool DBManager::getAllMeals(std::vector<std::tuple<int, std::string, std::string>> &meals) {
+bool DBManager::getAllMeals(std::vector<std::tuple<int, std::string, std::string, bool>> &meals) {
     std::lock_guard<std::recursive_mutex> lock(d_mutex);
     if (!d_db) return false;
 
-    std::string query = "SELECT id, name, category FROM meals ORDER BY name ASC;";
+    std::string query = "SELECT id, name, category, verified FROM meals ORDER BY name ASC;";
     sqlite3_stmt *stmt = nullptr;
 
     if (sqlite3_prepare_v2(d_db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
@@ -422,7 +446,8 @@ bool DBManager::getAllMeals(std::vector<std::tuple<int, std::string, std::string
                     reinterpret_cast<const char *>(sqlite3_column_text(stmt, 2))) {
                 category = catText;
             }
-            meals.emplace_back(id, name, category);
+            bool verified = sqlite3_column_int(stmt, 3) != 0;
+            meals.emplace_back(id, name, category, verified);
         }
     }
     sqlite3_finalize(stmt);
@@ -576,7 +601,7 @@ bool DBManager::seedDefaultIngredients() {
 bool DBManager::seedDefaultMeals() {
     std::lock_guard<std::recursive_mutex> lock(d_mutex);
     // This will seed the database with the initial hardcoded values if empty.
-    std::vector<std::tuple<int, std::string, std::string>> existing;
+    std::vector<std::tuple<int, std::string, std::string, bool>> existing;
     getAllMeals(existing);
     if (!existing.empty()) return true;  // Already seeded
 

--- a/src/db_manager.h
+++ b/src/db_manager.h
@@ -95,10 +95,10 @@ class DBManager {
     /**
      * @brief Retrieves a list of all available meal ids, names, and categories
      * from the database.
-     * @param meals Vector to populate with tuples of (id, name, category).
+     * @param meals Vector to populate with tuples of (id, name, category, verified).
      * @return true if successful, false otherwise.
      */
-    bool getAllMeals(std::vector<std::tuple<int, std::string, std::string>> &meals);
+    bool getAllMeals(std::vector<std::tuple<int, std::string, std::string, bool>> &meals);
 
     /**
      * @brief Returns the set of meal IDs that have at least one optional

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
 
         if (listMeals) {
             std::cout << "Available meals:" << std::endl;
-            std::vector<std::tuple<int, std::string, std::string>> meals;
+            std::vector<std::tuple<int, std::string, std::string, bool>> meals;
             factory.getAvailableMeals(meals);
             for (const auto &mealTuple : meals) {
                 std::cout << "-m " << std::get<1>(mealTuple) << " [" << std::get<2>(mealTuple)

--- a/src/meal.h
+++ b/src/meal.h
@@ -15,17 +15,20 @@ class Meal {
      * @param name The name of the meal.
      * @param ingredients The list of ingredients required.
      * @param category The category of the meal.
+     * @param verified Whether the recipe has been verified.
      */
     Meal(const std::string &name, const std::vector<Ingredient> &ingredients,
-         const std::string &category = "Uncategorized")
-        : d_name(name), d_ingredients(ingredients), d_category(category) {}
+         const std::string &category = "Uncategorized", bool verified = false)
+        : d_name(name), d_ingredients(ingredients), d_category(category), d_verified(verified) {}
 
     std::string getName() const { return d_name; }
     const std::vector<Ingredient> &getIngredients() const { return d_ingredients; }
     std::string getCategory() const { return d_category; }
+    bool isVerified() const { return d_verified; }
 
    private:
     std::string d_name;
     std::vector<Ingredient> d_ingredients;
     std::string d_category;
+    bool d_verified{false};
 };

--- a/src/meal_factory.cpp
+++ b/src/meal_factory.cpp
@@ -32,11 +32,12 @@ std::unique_ptr<Meal> MealFactory::createMeal(const std::string &mealName,
         }
         filtered.push_back(ing);
     }
-    return std::make_unique<Meal>(raw->getName(), filtered, raw->getCategory());
+    return std::make_unique<Meal>(raw->getName(), filtered, raw->getCategory(), raw->isVerified());
 }
 
 // Function to get all available meal names and categories
-void MealFactory::getAvailableMeals(std::vector<std::tuple<int, std::string, std::string>> &meals) {
+void MealFactory::getAvailableMeals(
+    std::vector<std::tuple<int, std::string, std::string, bool>> &meals) {
     if (d_dbManager) {
         d_dbManager->getAllMeals(meals);
     }

--- a/src/meal_factory.h
+++ b/src/meal_factory.h
@@ -53,7 +53,7 @@ class MealFactory {
      * meals.
      * @param meals The vector to populate.
      */
-    void getAvailableMeals(std::vector<std::tuple<int, std::string, std::string>> &meals);
+    void getAvailableMeals(std::vector<std::tuple<int, std::string, std::string, bool>> &meals);
 
    private:
     std::shared_ptr<DBManager> d_dbManager;

--- a/static/index.html
+++ b/static/index.html
@@ -245,6 +245,12 @@
                             <input type="text" id="meal-category" class="form-control"
                                 placeholder="e.g., Poultry, Breakfast" value="Uncategorized">
                         </div>
+                        <div class="form-group mt-2">
+                            <label class="verified-toggle" title="Mark this recipe as verified">
+                                <input type="checkbox" id="meal-verified">
+                                <span>✓ Verified recipe</span>
+                            </label>
+                        </div>
 
                         <h4>Ingredients</h4>
                         <div id="ingredients-list" class="ingredients-list">

--- a/static/script.js
+++ b/static/script.js
@@ -165,10 +165,12 @@ function renderMeals(meals) {
 
             const hasOptional = !!meal.has_optional_ingredients;
             const customizeHint = hasOptional ? '<span class="meal-card-customize">+ add-ons</span>' : '';
+            const verifiedBadge = meal.verified ? '<span class="verified-badge" title="Verified recipe">✓ Verified</span>' : '';
 
             card.innerHTML = `
                 <div class="meal-card-header">
                     <h3>${emoji} ${formatName(mealId)}</h3>
+                    ${verifiedBadge}
                     ${customizeHint}
                 </div>
                 <div class="meal-card-addons" hidden></div>
@@ -908,10 +910,15 @@ async function fetchManageMeals() {
 
             const formatName = str => str.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
 
+            const verifiedBadge = meal.verified
+                ? '<span class="verified-badge" style="margin-left:8px;" title="Verified recipe">✓ Verified</span>'
+                : '';
+
             item.innerHTML = `
                 <div class="manage-item-info">
                     <strong>${formatName(mealId)}</strong>
                     <span class="badge" style="margin-left:8px; font-size:0.8rem; background:var(--primary-color); padding:2px 6px; border-radius:4px; color:white;">${meal.category}</span>
+                    ${verifiedBadge}
                     <br><small style="color: var(--text-secondary);">${mealId}</small>
                     <br><small style="color: var(--text-secondary);">ID: ${meal.id}</small>
                 </div>
@@ -946,6 +953,7 @@ async function editMeal(mealId) {
         if (mealRes.ok) {
             const mealData = await mealRes.json();
             document.getElementById('meal-category').value = mealData.category || "Uncategorized";
+            document.getElementById('meal-verified').checked = !!mealData.verified;
             mealData.ingredients.forEach(ing => {
                 addIngredientRow(ing.name, ing.amount, ing.unit, !!ing.optional);
             });
@@ -1034,6 +1042,7 @@ async function saveMeal(e) {
 
     const name = document.getElementById('meal-name').value.trim().toLowerCase().replace(/\s+/g, '-');
     const category = document.getElementById('meal-category').value.trim() || 'Uncategorized';
+    const verified = document.getElementById('meal-verified').checked;
     const ingredientRows = document.querySelectorAll('.ingredient-row');
 
     if (ingredientRows.length === 0) {
@@ -1052,7 +1061,7 @@ async function saveMeal(e) {
         });
     });
 
-    const payload = { name, category, ingredients };
+    const payload = { name, category, verified, ingredients };
 
     try {
         const method = currentEditMeal ? 'PUT' : 'POST';

--- a/static/style.css
+++ b/static/style.css
@@ -1186,6 +1186,35 @@ h1 {
     cursor: pointer;
 }
 
+/* Verified-recipe badge — shown on meal cards and in the manage list */
+.verified-badge {
+    display: inline-block;
+    margin-left: var(--s-1);
+    padding: 1px 6px;
+    border-radius: 2px;
+    background: rgba(34, 197, 94, 0.15);
+    color: #16a34a;
+    font-size: 10px;
+    font-weight: 700;
+    vertical-align: middle;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+}
+
+/* Verified toggle in the recipe edit form */
+.verified-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.verified-toggle input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+}
+
 /* Recipe-tile hint that this meal has selectable add-ons */
 .meal-card-customize {
     display: inline-block;

--- a/tests/test_db_manager.cpp
+++ b/tests/test_db_manager.cpp
@@ -41,6 +41,45 @@ TEST_F(DBManagerTest, AddAndGetMeal) {
     EXPECT_EQ(retrieved->getIngredients()[0].getAmount().getUnit(), MeasurementUnit::POUND);
 }
 
+// verified defaults to false and round-trips through add/get
+TEST_F(DBManagerTest, VerifiedFlagDefaultsFalse) {
+    db->addMeal(makeMeal("unverified-meal"));
+    auto retrieved = db->getMeal("unverified-meal");
+    ASSERT_NE(retrieved, nullptr);
+    EXPECT_FALSE(retrieved->isVerified());
+}
+
+// addMeal persists the verified flag and getMeal/getAllMeals report it
+TEST_F(DBManagerTest, VerifiedFlagPersists) {
+    std::vector<Ingredient> ings = {
+        Ingredient("Chicken", Measurement(1.0, MeasurementUnit::POUND))};
+    Meal meal("verified-meal", ings, "Poultry", true);
+    EXPECT_TRUE(db->addMeal(meal));
+
+    auto retrieved = db->getMeal("verified-meal");
+    ASSERT_NE(retrieved, nullptr);
+    EXPECT_TRUE(retrieved->isVerified());
+
+    std::vector<std::tuple<int, std::string, std::string, bool>> meals;
+    EXPECT_TRUE(db->getAllMeals(meals));
+    ASSERT_EQ(meals.size(), 1u);
+    EXPECT_TRUE(std::get<3>(meals[0]));
+}
+
+// updateMeal can toggle the verified flag
+TEST_F(DBManagerTest, UpdateMealTogglesVerified) {
+    db->addMeal(makeMeal("toggle-me"));  // unverified by default
+
+    std::vector<Ingredient> ings = {
+        Ingredient("Chicken", Measurement(1.0, MeasurementUnit::POUND))};
+    Meal updated("toggle-me", ings, "Test", true);
+    EXPECT_TRUE(db->updateMeal(updated));
+
+    auto retrieved = db->getMeal("toggle-me");
+    ASSERT_NE(retrieved, nullptr);
+    EXPECT_TRUE(retrieved->isVerified());
+}
+
 // getMeal for a name not in the DB returns nullptr
 TEST_F(DBManagerTest, GetNonExistentMealReturnsNull) {
     auto result = db->getMeal("does-not-exist");
@@ -80,7 +119,7 @@ TEST_F(DBManagerTest, GetAllMealsReturnsAllEntries) {
     db->addMeal(makeMeal("meal-b", "Cat2"));
     db->addMeal(makeMeal("meal-a", "Cat1"));
 
-    std::vector<std::tuple<int, std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string, bool>> meals;
     EXPECT_TRUE(db->getAllMeals(meals));
     ASSERT_EQ(meals.size(), 2u);
     EXPECT_EQ(std::get<1>(meals[0]), "meal-a");  // ordered ASC
@@ -89,7 +128,7 @@ TEST_F(DBManagerTest, GetAllMealsReturnsAllEntries) {
 
 // getAllMeals on empty DB returns empty vector
 TEST_F(DBManagerTest, GetAllMealsEmptyDB) {
-    std::vector<std::tuple<int, std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string, bool>> meals;
     EXPECT_TRUE(db->getAllMeals(meals));
     EXPECT_TRUE(meals.empty());
 }
@@ -145,7 +184,7 @@ TEST_F(DBManagerTest, SeedDefaultIngredientsIsIdempotent) {
 TEST_F(DBManagerTest, SeedDefaultMealsPopulatesTable) {
     EXPECT_TRUE(db->seedDefaultMeals());
 
-    std::vector<std::tuple<int, std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string, bool>> meals;
     db->getAllMeals(meals);
     EXPECT_GT(meals.size(), 0u);
 }
@@ -153,11 +192,11 @@ TEST_F(DBManagerTest, SeedDefaultMealsPopulatesTable) {
 // seedDefaultMeals is idempotent
 TEST_F(DBManagerTest, SeedDefaultMealsIsIdempotent) {
     db->seedDefaultMeals();
-    std::vector<std::tuple<int, std::string, std::string>> first;
+    std::vector<std::tuple<int, std::string, std::string, bool>> first;
     db->getAllMeals(first);
 
     db->seedDefaultMeals();
-    std::vector<std::tuple<int, std::string, std::string>> second;
+    std::vector<std::tuple<int, std::string, std::string, bool>> second;
     db->getAllMeals(second);
 
     EXPECT_EQ(first.size(), second.size());
@@ -295,7 +334,7 @@ TEST_F(DBManagerTest, GetMealIdsWithOptionalIngredients) {
 
     auto ids = db->getMealIdsWithOptionalIngredients();
 
-    std::vector<std::tuple<int, std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string, bool>> meals;
     db->getAllMeals(meals);
     int noOptionsId = -1, withOptionsId = -1;
     for (const auto &m : meals) {

--- a/tests/test_meal.cpp
+++ b/tests/test_meal.cpp
@@ -21,6 +21,19 @@ TEST_F(MealTest, MealConstructorAndGetters) {
     EXPECT_EQ(meal.getIngredients().size(), 2);
     EXPECT_EQ(meal.getIngredients()[0].getName(), "Spinach");
     EXPECT_EQ(meal.getIngredients()[1].getName(), "Salt");
+    EXPECT_FALSE(meal.isVerified());  // defaults to unverified
+}
+
+// Test the verified flag through the constructor
+TEST_F(MealTest, VerifiedFlag) {
+    std::vector<Ingredient> ingredients = {
+        Ingredient("Spinach", Measurement(2.0, MeasurementUnit::CUP))};
+
+    Meal verifiedMeal("Verified Meal", ingredients, "Dinner", true);
+    EXPECT_TRUE(verifiedMeal.isVerified());
+
+    Meal unverifiedMeal("Unverified Meal", ingredients, "Dinner", false);
+    EXPECT_FALSE(unverifiedMeal.isVerified());
 }
 
 // Test that ingredients are immutable through getter

--- a/tests/test_meal_factory.cpp
+++ b/tests/test_meal_factory.cpp
@@ -51,7 +51,7 @@ TEST_F(MealFactoryTest, CaseSensitivity) {
 
 // Test getAvailableMeals
 TEST_F(MealFactoryTest, GetAvailableMeals) {
-    std::vector<std::tuple<int, std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string, bool>> meals;
     factory->getAvailableMeals(meals);
 
     EXPECT_GT(meals.size(), 0);
@@ -118,7 +118,7 @@ TEST_F(MealFactoryTest, CreateMealIncludesSelectedAddOns) {
 
 // Test that all available meals can be creatable
 TEST_F(MealFactoryTest, AllAvailableMealsAreCreatable) {
-    std::vector<std::tuple<int, std::string, std::string>> meals;
+    std::vector<std::tuple<int, std::string, std::string, bool>> meals;
     factory->getAvailableMeals(meals);
 
     for (const auto &mealTuple : meals) {


### PR DESCRIPTION
Adds a "verified" boolean to recipes so they can be marked as verified
in the Manage Recipes editor and surfaced with a badge on the main page.

- Meal model: new `verified` field with `isVerified()` getter
- DB: `verified` column on meals table + migration for existing DBs;
  persisted/read in addMeal, updateMeal, getMeal, getAllMeals
- API: parse `verified` on POST/PUT, return it on GET endpoints
- Frontend: "Verified recipe" checkbox in the edit form, green
  "✓ Verified" badge on meal cards and in the manage list
- Tests: cover the flag default, persistence, and update toggle